### PR TITLE
sentrycore: wrap error with log message

### DIFF
--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -111,9 +111,11 @@ func (w *worker) capture(errCtx *errorContext) {
 		//
 		// Additionally we include prefix the error with the log message, because usually
 		// when we log an error it is analagous to "wrapping" the error with a fixed
-		// description.
-		event.Exception[0].Type = fmt.Sprintf("%s: %s",
-			errCtx.Message, errors.Cause(errCtx.Error).Error())
+		// description. And of course we include the scope, because we want to promote
+		// its use as ways to identify and understand the context of observability
+		// elements.
+		event.Exception[0].Type = fmt.Sprintf("[%s] %s: %s",
+			errCtx.Scope, errCtx.Message, errors.Cause(errCtx.Error).Error())
 	}
 
 	// Tags are indexed fields that can be used to filter errors with.

--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -108,7 +108,12 @@ func (w *worker) capture(errCtx *errorContext) {
 		// which is very sensitive to move up/down lines. Using the original error
 		// string would be much more readable. We are also not losing location
 		// information because that is also encoded in the stack trace.
-		event.Exception[0].Type = errors.Cause(errCtx.Error).Error()
+		//
+		// Additionally we include prefix the error with the log message, because usually
+		// when we log an error it is analagous to "wrapping" the error with a fixed
+		// description.
+		event.Exception[0].Type = fmt.Sprintf("%s: %s",
+			errCtx.Message, errors.Cause(errCtx.Error).Error())
 	}
 
 	// Tags are indexed fields that can be used to filter errors with.


### PR DESCRIPTION
Right now, error messages are super non-descript because most context is in the _log_ message, not in the error message. I think it's useful to have the log message here because it also matters _where_ each error is being reported from, so grouping by log messages is something we probably want.

And of course we add the scope, because we want those to become important keys in navigating observability reports.

<img width="671" alt="image" src="https://user-images.githubusercontent.com/23356519/173163243-0ee30714-715a-44bb-81c7-c94713a35caf.png">
