### PR TITLE
sinks: document and reduce public API surface

### DIFF
--- a/init.go
+++ b/init.go
@@ -34,7 +34,8 @@ type PostInitializationCallbacks struct {
 // It must be called on service startup, i.e. 'main()', NOT on an 'init()' function.
 // Subsequent calls will panic, so do not call this within a non-service context.
 //
-// Init returns a callback, sync, that should be called before application exit.
+// Init returns a set of callbacks - see PostInitializationCallbacks for more details.
+// The Sync callback in particular must be called before application exit.
 //
 // For testing, you can use 'logtest.Init' to initialize the logging library.
 //
@@ -48,9 +49,8 @@ func Init(r Resource, s ...Sink) *PostInitializationCallbacks {
 	format := encoders.ParseOutputFormat(os.Getenv(envSrcLogFormat))
 	development := os.Getenv(envSrcDevelopment) == "true"
 
-	sinks := Sinks(s)
-	update := sinks.Update
-	cores, err := sinks.Build()
+	ss := sinks(s)
+	cores, err := ss.build()
 	sync := globallogger.Init(r, level, format, development, cores)
 
 	if err != nil {
@@ -60,6 +60,6 @@ func Init(r Resource, s ...Sink) *PostInitializationCallbacks {
 
 	return &PostInitializationCallbacks{
 		Sync:   sync,
-		Update: update,
+		Update: ss.update,
 	}
 }

--- a/init.go
+++ b/init.go
@@ -18,9 +18,9 @@ const (
 
 type Resource = otfields.Resource
 
-// PostInitializationCallbacks wraps the callbacks that enables to sync and update the
-// sinks used by the logger on configuration changes.
-type PostInitializationCallbacks struct {
+// PostInitCallbacks is a set of callbacks returned by Init that enables finalization and
+// updating of any configured sinks.
+type PostInitCallbacks struct {
 	// Sync must be called before application exit, such as via defer.
 	Sync func() error
 
@@ -34,13 +34,13 @@ type PostInitializationCallbacks struct {
 // It must be called on service startup, i.e. 'main()', NOT on an 'init()' function.
 // Subsequent calls will panic, so do not call this within a non-service context.
 //
-// Init returns a set of callbacks - see PostInitializationCallbacks for more details.
-// The Sync callback in particular must be called before application exit.
+// Init returns a set of callbacks - see PostInitCallbacks for more details. The Sync
+// callback in particular must be called before application exit.
 //
 // For testing, you can use 'logtest.Init' to initialize the logging library.
 //
 // If Init is not called, Get will panic.
-func Init(r Resource, s ...Sink) *PostInitializationCallbacks {
+func Init(r Resource, s ...Sink) *PostInitCallbacks {
 	if globallogger.IsInitialized() {
 		panic("log.Init initialized multiple times")
 	}
@@ -58,7 +58,7 @@ func Init(r Resource, s ...Sink) *PostInitializationCallbacks {
 		Scoped("log.init", "logger initialization").Fatal("core initialization failed", Error(err))
 	}
 
-	return &PostInitializationCallbacks{
+	return &PostInitCallbacks{
 		Sync:   sync,
 		Update: ss.update,
 	}

--- a/internal/configurable/logger.go
+++ b/internal/configurable/logger.go
@@ -1,0 +1,20 @@
+package configurable
+
+import (
+	"go.uber.org/zap/zapcore"
+
+	"github.com/sourcegraph/log"
+)
+
+// Logger exposes internal APIs that must be implemented on
+// github.com/sourcegraph/log.zapAdapter
+type Logger interface {
+	log.Logger
+
+	// WithCore is an internal API used to allow packages like logtest to hook into
+	// underlying zap logger's core.
+	WithCore(func(c zapcore.Core) zapcore.Core) log.Logger
+}
+
+// Cast provides a configurable logger API for testing purposes.
+func Cast(l log.Logger) Logger { return l.(Logger) }

--- a/internal/configurable/logger_test.go
+++ b/internal/configurable/logger_test.go
@@ -1,0 +1,24 @@
+package configurable_test
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/internal/configurable"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestCast(t *testing.T) {
+	assert.NotPanics(t, func() {
+		log.Init(log.Resource{Name: t.Name()})
+
+		// Cast works
+		cl := configurable.Cast(log.Scoped("foo", "bar"))
+
+		// Core wrapping works
+		_ = cl.WithCore(func(c zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(c, zapcore.NewNopCore())
+		})
+	})
+}

--- a/internal/sinkcores/sentrycore/integration_test.go
+++ b/internal/sinkcores/sentrycore/integration_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/internal/configurable"
 	"github.com/sourcegraph/log/internal/sinkcores/sentrycore"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -269,9 +271,21 @@ func logWithLevel(logger log.Logger, level zapcore.Level, msg string, fields ...
 
 func newTestLogger(t testing.TB) (log.Logger, *sentrycore.TransportMock, func()) {
 	transport := &sentrycore.TransportMock{}
-	sink := log.NewSentrySinkWithOptions(sentry.ClientOptions{Transport: transport})
-	logger, exportLogs := logtest.Captured(t, sink)
-	return logger, transport, func() { _ = exportLogs() }
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+
+	core := sentrycore.NewCore(sentry.NewHub(client, sentry.NewScope()))
+
+	cl := configurable.Cast(logtest.Scoped(t))
+
+	return cl.WithCore(func(c zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(c, core)
+		}),
+		transport,
+		func() {
+			err := core.Sync()
+			require.NoError(t, err)
+		}
 }
 
 func newTestHub(t testing.TB) (*sentry.Hub, *sentrycore.TransportMock) {

--- a/logger.go
+++ b/logger.go
@@ -201,7 +201,8 @@ func (z *zapAdapter) IncreaseLevel(scope string, description string, level Level
 // WithCore is an internal API used to allow packages like logtest to hook into
 // underlying zap logger's core.
 //
-// It must implement logtest.configurableAdapter
+// It must implement internal/configurable.Logger. We do not assert it, however, because
+// that would cause an import cycle - instead, there is a test in package configurable.
 func (z *zapAdapter) WithCore(f func(c zapcore.Core) zapcore.Core) Logger {
 	newRootLogger := z.rootLogger.
 		WithOptions(zap.WrapCore(f))

--- a/sinks.go
+++ b/sinks.go
@@ -4,38 +4,47 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// Sink describes additional destinations that github.com/sourcegraph/log can send log
+// entries to. It can only be implmented directly within the package.
 type Sink interface {
-	Build() (zapcore.Core, error)
+	Name() string
+
+	// build creates the core to attach to the root logger. The implementation should
+	// maintain a reference to anything needed to update this core, as a Sink will only
+	// ever be built once.
+	build() (zapcore.Core, error)
+	// update is called on the `Update` callback from `log.Init` with new configuration.
 	update(SinksConfig) error
 }
 
+// SinksConfig describes unified configuration for all sinks.
 type SinksConfig struct {
 	Sentry *SentrySink
 }
 
-type Sinks []Sink
+type sinks []Sink
 
+// SinksConfigGetter should provide the latest SinksConfig to update sink configuration.
 type SinksConfigGetter func() SinksConfig
 
-func (s Sinks) Update(get SinksConfigGetter) func() {
+func (s sinks) update(get SinksConfigGetter) func() {
 	return func() {
 		updated := get()
 
 		for _, sink := range s {
 			if err := sink.update(updated); err != nil {
-				logger := Scoped("conf", "configuration").
-					Scoped("sentry-sink", "Logger extension that capture errors into Sentry")
-				logger.Error("failed to update", Error(err))
+				Scoped("sinks.update", "configuration updates").
+					Error("failed to update", String("sink", sink.Name()), Error(err))
 			}
 		}
 	}
 }
 
-func (s Sinks) Build() ([]zapcore.Core, error) {
+func (s sinks) build() ([]zapcore.Core, error) {
 	var cores []zapcore.Core
 
 	for _, sink := range s {
-		sc, err := sink.Build()
+		sc, err := sink.build()
 		if err != nil {
 			return nil, err
 		}

--- a/sinks.go
+++ b/sinks.go
@@ -33,7 +33,7 @@ func (s sinks) update(get SinksConfigGetter) func() {
 
 		for _, sink := range s {
 			if err := sink.update(updated); err != nil {
-				Scoped("sinks.update", "configuration updates").
+				Scoped("log.sinks.update", "configuration updates").
 					Error("failed to update", String("sink", sink.Name()), Error(err))
 			}
 		}


### PR DESCRIPTION
Was looking to have [an answer to this Slack question documented in the package docs](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1654903757077709), and noticed a variety of improvements we could make to improve the readability of our [package docs](https://pkg.go.dev/github.com/sourcegraph/log):

- `Sink` has many exported functions that do not need to be exported, so we make `build` and `update` private to reduce the documentation here. This also prevents package users from building their own implementations, which we can't guarantee the behaviour of
- `Sinks` does not need to be used directly, so we make it private, which also nicely removes all the exports of `zapcore.Core`
- There are usages of `Sinks` in testing that can be replaced with using the private `WithCore` hook, so we make that an internal package and replace the usage of sinks with that. We also remove the additional arguments from `logtest`, because package users should not be testing their own sink implementations.
- Improve the logging in `sinks.update` by adding `Name()` to the `Sink` interface
- A bit tangential, but `PostInitializationCallbacks` -> `PostInitCallbacks` and improved docs there (name change better aligns with the `Init` func)

And of course, I've added some documentation to things that remain exported.