### PR TITLE
logtest: init only once

### DIFF
--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -2,6 +2,7 @@ package logtest
 
 import (
 	"flag"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,9 @@ import (
 	"github.com/sourcegraph/log/otfields"
 )
 
+// stdTestInit guards the initialization of the standard library testing package.
+var stdTestInit sync.Once
+
 // Init can be used to instantiate the log package for running tests, to be called in
 // TestMain for the relevant package. Remember to call (*testing.M).Run() after initializing
 // the logger!
@@ -23,9 +27,12 @@ import (
 // testing.M is an unused argument, used to indicate this function should be called in
 // TestMain.
 func Init(_ *testing.M) {
-	// ensure Verbose is set up
-	testing.Init()
-	flag.Parse()
+	stdTestInit.Do(func() {
+		// ensure Verbose and standard library testing stuff is set up
+		testing.Init()
+		flag.Parse()
+	})
+
 	// set reasonable defaults
 	if testing.Verbose() {
 		initGlobal(zapcore.DebugLevel)


### PR DESCRIPTION
We init liberally in logtest for a more seamless experience, but the init hook inside logtest also reaches into standard test library setup that is not thread-safe, leading to race conditions:

https://buildkite.com/sourcegraph/sourcegraph/builds/155034#01816c05-1bbd-4041-a362-e7caeb8af6a8/6-3302

```
\| WARNING: DATA RACE
--
  | \| Read at 0x00c0000c0138 by goroutine 88:
  | \|   flag.(*FlagSet).Parsed()
... truncated ...
\|   flag.Parse()
--
  | \|       /root/.asdf/installs/golang/1.18.1/go/src/flag/flag.go:1036 +0xcf
  | \|   github.com/sourcegraph/log/logtest.Init()
  | \|       /root/.asdf/installs/golang/1.18.1/packages/pkg/mod/github.com/sourcegraph/log@v0.0.0-20220613150728-bb50c87ba841/logtest/logtest.go:28 +0x3b
  | \|   github.com/sourcegraph/log/logtest.scopedTestLogger()
  | \|       /root/.asdf/installs/golang/1.18.1/packages/pkg/mod/github.com/sourcegraph/log@v0.0.0-20220613150728-bb50c87ba841/logtest/logtest.go:70 +0x4b
  | \|   github.com/sourcegraph/log/logtest.Scoped()
  | \|       /root/.asdf/installs/golang/1.18.1/packages/pkg/mod/github.com/sourcegraph/log@v0.0.0-20220613150728-bb50c87ba841/logtest/logtest.go:95 +0x3c7


```