### PR TITLE
levels: default to WarnLevel

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -40,6 +40,7 @@ func (l Level) Parse() zapcore.Level {
 		// silences all output.
 		return zapcore.FatalLevel
 	}
-	// Quietly fall back to info
-	return zapcore.InfoLevel
+
+	// Quietly fall back to warn
+	return zapcore.WarnLevel
 }


### PR DESCRIPTION
I mistakenly let this default to `info`, but that introduces a discrepancy with existing behaviour, which defaults to `warn` (https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/env/env.go?L31%3A2=)