### PR TITLE
fields: add Binary, missing numeric fields

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -29,6 +29,8 @@ var (
 	Ints = zap.Ints
 	// Int32s constructs a field that carries a slice of 32 bit integers.
 	Int32s = zap.Int32s
+	// Int64s constructs a field that carries a slice of integers.
+	Int64s = zap.Int64s
 
 	// Uint constructs a field with the given key and value.
 	Uint = zap.Uint
@@ -37,12 +39,27 @@ var (
 	// Uint64 constructs a field with the given key and value.
 	Uint64 = zap.Uint64
 
+	// Float32 constructs a field that carries a float32. The way the
+	// floating-point value is represented is encoder-dependent, so marshaling is
+	// necessarily lazy.
+	Float32 = zap.Float32
+	// Float32s constructs a field that carries a slice of floats.
+	Float32s = zap.Float32s
 	// Float64 constructs a field that carries a float64. The way the floating-point value
 	// is represented is encoder-dependent, so marshaling is necessarily lazy.
 	Float64 = zap.Float64
+	// Float64s constructs a field that carries a slice of floats.
+	Float64s = zap.Float64s
 
 	// Bool constructs a field that carries a bool.
 	Bool = zap.Bool
+
+	// Binary constructs a field that carries an opaque binary blob.
+	//
+	// Binary data is serialized in an encoding-appropriate format. For example,
+	// zap's JSON encoder base64-encodes binary blobs. To log UTF-8 encoded text,
+	// use ByteString.
+	Binary = zap.Binary
 
 	// Duration constructs a field with the given key and value. The encoder controls how
 	// the duration is serialized.


### PR DESCRIPTION
Adds `Binary` (reqeusted in https://github.com/sourcegraph/sourcegraph/pull/37536#discussion_r905931022) and other potentially useful numeric primitives.

The linked comment also comments on the weight of making these changes - my thoughts:

- We want to make sure we shim everything, because we inject some custom behaviour (notably with the log.Error field), and we want to make sure nobody uses zap.Any, so I think this overhead is _worthwhile_
- I think we're pretty close to covering all the most frequently used fields - we've only had 2 requests for new fields to date (this one, and https://github.com/sourcegraph/log/pull/7), so I think this is a _manageable_ overhead as well