### PR TITLE
Only send to Sentry logs on Error level and above

### DIFF
--- a/internal/sinkcores/sentrycore/core.go
+++ b/internal/sinkcores/sentrycore/core.go
@@ -145,9 +145,9 @@ func (c *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	return nil
 }
 
-// Enabled returns false when the log level is below the Warn level.
+// Enabled returns false when the log level is below the Error level.
 func (c *Core) Enabled(level zapcore.Level) bool {
-	return level >= zapcore.WarnLevel
+	return level >= zapcore.ErrorLevel
 }
 
 // Sync ensure that the remaining event are flushed, but has a hard limit of TODO seconds

--- a/internal/sinkcores/sentrycore/doc.go
+++ b/internal/sinkcores/sentrycore/doc.go
@@ -1,9 +1,9 @@
 // sentrycore provides a Sentry sink, that captures errors passed to the logger with the log.Error
-// function if and only if the log level is superior or equal to Warn.
+// function if and only if the log level is superior or equal to Error.
 //
 // In order to not slow down logging when it's not necessary:
 //
-// a) the underlying zapcore.Core is only processing logging events on Warn and above levels.
+// a) the underlying zapcore.Core is only processing logging events on Error and above levels.
 //
 // b) consuming log events and processing them for sentry reporting are both asynchronous. This deflects
 // most of the work into the processing go routine and leverage Sentry's client ability to send reports in batches.

--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -127,9 +127,6 @@ func (w *worker) capture(errCtx *errorContext) {
 		// so we can distinguish it from other levels and easily identify them
 		tags["panic_in_development"] = "true"
 	}
-	if errCtx.Level == zapcore.WarnLevel {
-		tags["transient"] = "true"
-	}
 
 	// Add the logging context, extra is deprecated by Sentry:
 	// https://docs.sentry.io/platforms/go/enriching-events/context/#additional-data


### PR DESCRIPTION
After taking another look at our Sentry reports, the good news is that most of the errors sent with a warning level are indeed transient. The bad news is we can't really filter those out automatically and to be frank it doesn't make much sense to do so. 

The value of an error on Sentry is that it's a useful signal and transient errors are not fitting that case that much. 

I originally kept those in when writing this code because I was curious to see what kind of transient errors we were reporting. 

So at this point, I think it's better to simply stop getting those reported. Using metrics to track how those errors are evolving is a much better signal and will create much less noise. 

Were we to decide otherwise and to make this togglable, it's just a revert away on this PR. I went against it, because adding moving parts where we aren't using them is a dangerous road :D 