### PR TITLE
fields: make Ptr a deref API instead of a field API

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -1,8 +1,6 @@
 package log
 
 import (
-	"time"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -105,7 +103,7 @@ func NamedError(key string, err error) Field {
 
 // ptrValueTypes lists all acceptable pointer types for creating fields.
 type ptrValueTypes interface {
-	~string | ~int | ~int32 | ~int64 | ~uint | ~uint32 | ~uint64 | ~float32 | ~float64 | ~bool | time.Time
+	~string | ~int | ~int32 | ~int64 | ~uint | ~uint32 | ~uint64 | ~float32 | ~float64 | ~bool
 }
 
 // Ptr safely dereferences a value for use in a log field, rendering a zero value if the

--- a/logger_test.go
+++ b/logger_test.go
@@ -77,15 +77,14 @@ func TestLoggerPtrFie(t *testing.T) {
 	strPtr := &str
 	var nilStrPtr *string
 
-	logger.Info("ptr", log.Ptr("str", strPtr), log.Ptr("nilptr", nilStrPtr))
-
-	// This doesn't compile, meaning the implementation is correct.
-	// logger.Info("ptr", log.Ptr("str", nil))
+	logger.Info("ptr",
+		log.String("str", log.Ptr(strPtr)),
+		log.String("nilptr", log.Ptr(nilStrPtr)))
 
 	logs := exportLogs()
 
 	assert.Equal(t, map[string]interface{}{
 		"str":    str,
-		"nilptr": nil,
+		"nilptr": "",
 	}, logs[0].Fields["Attributes"])
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,6 +2,7 @@ package log_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -75,16 +76,21 @@ func TestLoggerPtrFie(t *testing.T) {
 
 	str := "foo"
 	strPtr := &str
-	var nilStrPtr *string
+	var (
+		nilStrPtr   *string
+		durationPtr *time.Duration
+	)
 
 	logger.Info("ptr",
 		log.String("str", log.Ptr(strPtr)),
-		log.String("nilptr", log.Ptr(nilStrPtr)))
+		log.String("nilptr", log.Ptr(nilStrPtr)),
+		log.Duration("durptr", log.Ptr(durationPtr)))
 
 	logs := exportLogs()
 
 	assert.Equal(t, map[string]interface{}{
 		"str":    str,
 		"nilptr": "",
+		"durptr": time.Duration(0),
 	}, logs[0].Fields["Attributes"])
 }


### PR DESCRIPTION
Alternative to https://github.com/sourcegraph/log/pull/14 which I think is better IMO, so that we can avoid `zap.Any`, keep the readability of the API to see what type something is, and avoid potential confusion where some field types are generic but others are not.

```go
	logger.Info("ptr",
		log.String("str", log.Ptr(strPtr)),
		log.String("nilStr", log.Ptr(nilStrPtr)))
```