### PR TITLE
Revert "Export a log.StringPtr function to safely log *string "

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -1,8 +1,6 @@
 package log
 
 import (
-	"time"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -88,20 +86,6 @@ func Object(key string, fields ...Field) Field {
 // Error is shorthand for the common idiom NamedError("error", err).
 func Error(err error) Field {
 	return NamedError("error", err)
-}
-
-// ptrFieldsTypes lists all acceptable pointer types for creating fields.
-//
-// Caveat: we can't use ~type because the type assertion switch in zap.Any will fail with a
-// custom type.
-type ptrFieldsTypes interface {
-	*string | *int | *int32 | *int64 | *uint | *uint32 | *uint64 | *float32 | *float64 | *bool | *time.Time | *time.Duration
-}
-
-// Ptr creates a field whose value is a pointer to a type that is supported by other fields functions from this package and
-// safely and explicitly represent `nil` when appropriate.
-func Ptr[T ptrFieldsTypes](key string, value T) Field {
-	return zap.Any(key, value)
 }
 
 // NamedError constructs a field that logs err.Error() under the provided key.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/log
 
-go 1.18
+go 1.17
 
 require (
 	github.com/cockroachdb/errors v1.9.0

--- a/logger_test.go
+++ b/logger_test.go
@@ -65,27 +65,3 @@ func TestLogger(t *testing.T) {
 		},
 	}, logs[4].Fields["Attributes"])
 }
-
-func TestLoggerPtrFie(t *testing.T) {
-	logger, exportLogs := logtest.Captured(t)
-	assert.NotNil(t, logger)
-	if globallogger.DevMode() {
-		logger = logger.With(otfields.AttributesNamespace)
-	}
-
-	str := "foo"
-	strPtr := &str
-	var nilStrPtr *string
-
-	logger.Info("ptr", log.Ptr("str", strPtr), log.Ptr("nilptr", nilStrPtr))
-
-	// This doesn't compile, meaning the implementation is correct.
-	// logger.Info("ptr", log.Ptr("str", nil))
-
-	logs := exportLogs()
-
-	assert.Equal(t, map[string]interface{}{
-		"str":    str,
-		"nilptr": nil,
-	}, logs[0].Fields["Attributes"])
-}


### PR DESCRIPTION
Reverts sourcegraph/log#14

IMO we should just use `StringPtr`, `IntPtr`, etc for clarity and API consistency, and avoid using what is effectively an equivalent of `zap.Any` - my generic idea was somewhat miscommunicated, and the actual intent of that idea turns out to not be a great idea, so we should just go with the perhaps verbose but arguably more correct way of doing things. See discussion in https://github.com/sourcegraph/log/pull/15