### PR TITLE
sinkcores/outputcore: extract default core into a Sink

### DIFF
--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -1,0 +1,22 @@
+package outputcore
+
+import (
+	"github.com/sourcegraph/log/internal/encoders"
+	"go.uber.org/zap/zapcore"
+)
+
+func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat) zapcore.Core {
+	return zapcore.NewCore(
+		encoders.BuildEncoder(format, false),
+		output,
+		level,
+	)
+}
+
+func NewDevelopmentCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat) zapcore.Core {
+	return zapcore.NewCore(
+		encoders.BuildEncoder(format, true),
+		output,
+		level,
+	)
+}

--- a/internal/stderr/stderr.go
+++ b/internal/stderr/stderr.go
@@ -1,0 +1,14 @@
+package stderr
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func Open() (zapcore.WriteSyncer, error) {
+	errSink, _, err := zap.Open("stderr")
+	if err != nil {
+		return nil, err
+	}
+	return errSink, nil
+}

--- a/sinks_output.go
+++ b/sinks_output.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/sourcegraph/log/internal/encoders"
+	"github.com/sourcegraph/log/internal/sinkcores/outputcore"
+	"github.com/sourcegraph/log/internal/stderr"
+)
+
+type outputSink struct {
+	development bool
+}
+
+func (s *outputSink) Name() string { return "OutputSink" }
+
+func (s *outputSink) build() (zapcore.Core, error) {
+	output, err := stderr.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	level := zap.NewAtomicLevelAt(Level(os.Getenv(EnvLogLevel)).Parse())
+	format := encoders.ParseOutputFormat(os.Getenv(EnvLogFormat))
+
+	if s.development {
+		return outputcore.NewDevelopmentCore(output, level, format), nil
+	}
+	return outputcore.NewCore(output, level, format), nil
+}
+
+func (s *outputSink) update(updated SinksConfig) error {
+	return nil
+}


### PR DESCRIPTION
This change extracts the default core, writing to stderr, as a regular Sink. It is automatically included in `log.Init`. This simplifies a number of internal APIs significantly.

---

Outcome of a pairing session with @burmudar 