### PR TITLE
outputcore: add sampling

### DIFF
--- a/init.go
+++ b/init.go
@@ -17,6 +17,17 @@ const (
 	// EnvLogLevel is key of the environment variable that can be used to set the log
 	// level on Init.
 	EnvLogLevel = "SRC_LOG_LEVEL"
+	// EnvLogSamplingInitial is key of the environment variable that can be used to set
+	// the number of entries with identical messages to always output per second.
+	//
+	// Defaults to 100 - set explicitly to 0 or -1 to disable.
+	EnvLogSamplingInitial = "SRC_LOG_SAMPLING_INITIAL"
+	// EnvLogSamplingThereafter is key of the environment variable that can be used to set
+	// the number of entries with identical messages to discard before emitting another
+	// one per second, after EnvLogSamplingInitial.
+	//
+	// Defaults to 100 - set explicitly to 0 or -1 to disable.
+	EnvLogSamplingThereafter = "SRC_LOG_SAMPLING_THEREAFTER"
 )
 
 type Resource = otfields.Resource

--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -1,21 +1,41 @@
 package outputcore
 
 import (
+	"time"
+
 	"github.com/sourcegraph/log/internal/encoders"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat) zapcore.Core {
-	return zapcore.NewCore(
+// SamplingConfig enables sampling if Initial is set. Sampling is keyed off of the log
+// message only - see:
+//
+// - https://github.com/uber-go/zap/blob/master/FAQ.md#why-sample-application-logs
+// - https://github.com/uber-go/zap/blob/master/FAQ.md#why-do-the-structured-logging-apis-take-a-message-in-addition-to-fields
+type SamplingConfig struct {
+	// First n entries to always log
+	Initial int
+	// Only log each nth entry
+	Thereafter int
+}
+
+func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig) zapcore.Core {
+	core := zapcore.NewCore(
 		encoders.BuildEncoder(format, false),
 		output,
 		level,
 	)
+
+	if sampling.Initial > 0 {
+		return zapcore.NewSamplerWithOptions(core, time.Second, sampling.Initial, sampling.Thereafter)
+	}
+	return core
 }
 
 func NewDevelopmentCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat) zapcore.Core {
 	return zapcore.NewCore(
-		encoders.BuildEncoder(format, true),
+		encoders.BuildEncoder(encoders.OutputConsole, true),
 		output,
 		level,
 	)

--- a/logtest/core.go
+++ b/logtest/core.go
@@ -3,23 +3,7 @@ package logtest
 import (
 	"bytes"
 	"testing"
-
-	"github.com/sourcegraph/log/internal/encoders"
-	"go.uber.org/zap/zapcore"
 )
-
-// newTestingCore creates a core with the same encoder as our usual logging, but writes to
-// testing.TB instead.
-func newTestingCore(t testing.TB, level zapcore.LevelEnabler, failOnErrorLogs bool) zapcore.Core {
-	return zapcore.NewCore(
-		encoders.BuildEncoder(encoders.OutputConsole, true),
-		&testingWriter{
-			t:          t,
-			markFailed: failOnErrorLogs,
-		},
-		level,
-	)
-}
 
 // testingWriter is a WriteSyncer that writes to the given testing.TB.
 //

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -98,8 +98,12 @@ func scopedTestLogger(t testing.TB, options LoggerOptions) log.Logger {
 		if options.Level != "" {
 			level = zap.NewAtomicLevelAt(options.Level.Parse())
 		}
+
 		// replace the core entirely
-		return newTestingCore(t, level, options.FailOnErrorLogs)
+		return outputcore.NewDevelopmentCore(&testingWriter{
+			t:          t,
+			markFailed: options.FailOnErrorLogs,
+		}, level, encoders.OutputConsole)
 	})
 }
 


### PR DESCRIPTION
Adds sampling configured at startup via the following:

- `SRC_LOG_SAMPLING_INITIAL`
- `SRC_LOG_SAMPLING_THEREAFTER`

Both of the above default to 100. Supercedes https://github.com/sourcegraph/log/pull/19