### PR TITLE
Add overridable default sentry client options

### DIFF
--- a/internal/sinkcores/sentrycore/default_sentry_client_opts.go
+++ b/internal/sinkcores/sentrycore/default_sentry_client_opts.go
@@ -1,0 +1,17 @@
+package sentrycore
+
+import "github.com/getsentry/sentry-go"
+
+// DefaultSentryClientOptions represents the default options that are merged in the Sentry client options 
+// used to be build a SentryCore.
+var DefaultSentryClientOptions = sentry.ClientOptions{
+	SampleRate: 0.1,
+}
+
+// ApplySentryClientDefaultOptions merges ops with the defaults defined in DefaultSentryClientOptions.
+func ApplySentryClientDefaultOptions(opts sentry.ClientOptions) sentry.ClientOptions {
+	if opts.SampleRate != 0 {
+		opts.SampleRate = DefaultSentryClientOptions.SampleRate
+	}
+	return opts
+}

--- a/internal/sinkcores/sentrycore/default_sentry_client_opts.go
+++ b/internal/sinkcores/sentrycore/default_sentry_client_opts.go
@@ -8,7 +8,7 @@ var DefaultSentryClientOptions = sentry.ClientOptions{
 	SampleRate: 0.1,
 }
 
-// ApplySentryClientDefaultOptions merges ops with the defaults defined in DefaultSentryClientOptions.
+// ApplySentryClientDefaultOptions merges opts with the defaults defined in DefaultSentryClientOptions.
 func ApplySentryClientDefaultOptions(opts sentry.ClientOptions) sentry.ClientOptions {
 	if opts.SampleRate == 0 {
 		opts.SampleRate = DefaultSentryClientOptions.SampleRate

--- a/internal/sinkcores/sentrycore/default_sentry_client_opts.go
+++ b/internal/sinkcores/sentrycore/default_sentry_client_opts.go
@@ -2,7 +2,7 @@ package sentrycore
 
 import "github.com/getsentry/sentry-go"
 
-// DefaultSentryClientOptions represents the default options that are merged in the Sentry client options 
+// DefaultSentryClientOptions represents the default options that are merged in the Sentry client options
 // used to be build a SentryCore.
 var DefaultSentryClientOptions = sentry.ClientOptions{
 	SampleRate: 0.1,
@@ -10,7 +10,7 @@ var DefaultSentryClientOptions = sentry.ClientOptions{
 
 // ApplySentryClientDefaultOptions merges ops with the defaults defined in DefaultSentryClientOptions.
 func ApplySentryClientDefaultOptions(opts sentry.ClientOptions) sentry.ClientOptions {
-	if opts.SampleRate != 0 {
+	if opts.SampleRate == 0 {
 		opts.SampleRate = DefaultSentryClientOptions.SampleRate
 	}
 	return opts

--- a/sinks_sentry.go
+++ b/sinks_sentry.go
@@ -25,13 +25,19 @@ type sentrySink struct {
 }
 
 // NewSentrySink instantiates a Sentry sink to provide to `log.Init` with default options.
-func NewSentrySink() Sink { return &sentrySink{} }
+//
+// See sentrycore.DefaultSentryClientOptions for the default options.
+func NewSentrySink() Sink {
+	return &sentrySink{SentrySink: SentrySink{options: sentrycore.DefaultSentryClientOptions}}
+}
 
 // NewSentrySinkWithOptions instantiates a Sentry sink with advanced initial configuration
 // to provide to `log.Init`. Note that configuration, notably the Sentry DSN, may be
 // overwritten by subsequent calls to the `Update` callback from `log.Init`.
+//
+// See sentrycore.DefaultSentryClientOptions for the default options.
 func NewSentrySinkWithOptions(opts sentry.ClientOptions) Sink {
-	return &sentrySink{SentrySink: SentrySink{options: opts}}
+	return &sentrySink{SentrySink: SentrySink{options: sentrycore.ApplySentryClientDefaultOptions(opts)}}
 }
 
 func (s *sentrySink) Name() string { return "SentrySink" }

--- a/sinks_sentry_test.go
+++ b/sinks_sentry_test.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/log/internal/sinkcores/sentrycore"
+)
+
+func TestNewSentrySink(t *testing.T) {
+	t.Run("defaults are applied", func(t *testing.T) {
+		s := NewSentrySink()
+		ss, ok := s.(*sentrySink)
+		assert.True(t, ok)
+		assert.Equal(t, sentrycore.DefaultSentryClientOptions, ss.SentrySink.options)
+	})
+}
+
+func TestNewSentrySinkWithOptions(t *testing.T) {
+	t.Run("defaults are overridable", func(t *testing.T) {
+		s := NewSentrySinkWithOptions(sentry.ClientOptions{SampleRate: 0.5})
+		ss, ok := s.(*sentrySink)
+		assert.True(t, ok)
+		assert.Equal(t, 0.5, ss.SentrySink.options.SampleRate)
+	})
+	t.Run("defaults are merged", func(t *testing.T) {
+		s := NewSentrySinkWithOptions(sentry.ClientOptions{ServerName: "foobar"})
+		ss, ok := s.(*sentrySink)
+		assert.True(t, ok)
+		assert.Equal(t, "foobar", ss.SentrySink.options.ServerName)
+	})
+}

--- a/sinks_sentry_test.go
+++ b/sinks_sentry_test.go
@@ -25,6 +25,7 @@ func TestNewSentrySinkWithOptions(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, 0.5, ss.SentrySink.options.SampleRate)
 	})
+
 	t.Run("defaults are merged", func(t *testing.T) {
 		s := NewSentrySinkWithOptions(sentry.ClientOptions{ServerName: "foobar"})
 		ss, ok := s.(*sentrySink)


### PR DESCRIPTION
I went for keeping the ability to pass sentry client options directly rather than taking in an env var as it's kind of confusing to have an external module automatically reading env var. 

This sets the default sampling rate to 10%, which should be largely enough for our usage. As it's now a default, we'll be able to remove the configuring code that's present in the main funcs of every service. 
