### PR TITLE
log: fix devmode and safe logger instantiation

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,16 +1,14 @@
 package log
 
 import (
-	"os"
-
 	"github.com/sourcegraph/log/internal/globallogger"
 	"github.com/sourcegraph/log/otfields"
 )
 
-const (
+var (
 	// EnvDevelopment is key of the environment variable that is used to set whether
 	// to use development logger configuration on Init.
-	EnvDevelopment = "SRC_DEVELOPMENT"
+	EnvDevelopment = globallogger.EnvDevelopment
 	// EnvLogLevel is key of the environment variable that is used to set the log format
 	// on Init.
 	EnvLogFormat = "SRC_LOG_FORMAT"
@@ -59,13 +57,11 @@ func Init(r Resource, s ...Sink) *PostInitCallbacks {
 		panic("log.Init initialized multiple times")
 	}
 
-	development := os.Getenv(EnvDevelopment) == "true"
-
-	ss := sinks(append([]Sink{&outputSink{development: development}}, s...))
+	ss := sinks(append([]Sink{&outputSink{development: globallogger.DevMode()}}, s...))
 	cores, sinksBuildErr := ss.build()
 
 	// Init the logger first, so that we can log the error if needed
-	sync := globallogger.Init(r, development, cores)
+	sync := globallogger.Init(r, globallogger.DevMode(), cores)
 
 	if sinksBuildErr != nil {
 		// Log the error

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -1,6 +1,7 @@
 package globallogger
 
 import (
+	"os"
 	"sync"
 
 	"go.uber.org/zap"
@@ -13,7 +14,8 @@ import (
 )
 
 var (
-	devMode          bool
+	EnvDevelopment   = "SRC_DEVELOPMENT"
+	devMode          = os.Getenv(EnvDevelopment) == "true"
 	globalLogger     *zap.Logger
 	globalLoggerInit sync.Once
 )
@@ -36,6 +38,9 @@ func Get(safe bool) *zap.Logger {
 // Init initializes the global logger once. Subsequent calls are no-op. Returns the
 // callback to sync the root core.
 func Init(r otfields.Resource, development bool, sinks []zapcore.Core) func() error {
+	// Update global
+	devMode = development
+
 	globalLoggerInit.Do(func() {
 		globalLogger = initLogger(r, development, sinks)
 	})
@@ -48,9 +53,6 @@ func IsInitialized() bool {
 }
 
 func initLogger(r otfields.Resource, development bool, sinks []zapcore.Core) *zap.Logger {
-	// Set global
-	devMode = development
-
 	internalErrsSink, err := openStderr()
 	if err != nil {
 		panic(err.Error())

--- a/logger.go
+++ b/logger.go
@@ -83,8 +83,7 @@ type Logger interface {
 // When testing, you should use 'logtest.Scoped(*testing.T)' instead - learn more:
 // https://docs.sourcegraph.com/dev/how-to/add_logging#testing-usage
 func Scoped(scope string, description string) Logger {
-	devMode := globallogger.DevMode()
-	safeGet := !devMode // do not panic in prod
+	safeGet := !globallogger.DevMode() // do not panic in prod
 	root := globallogger.Get(safeGet)
 	adapted := &zapAdapter{
 		Logger:            root,
@@ -92,7 +91,7 @@ func Scoped(scope string, description string) Logger {
 		fromPackageScoped: true,
 	}
 
-	if devMode {
+	if globallogger.DevMode() {
 		// In development, don't add the OpenTelemetry "Attributes" namespace which gets
 		// rather difficult to read.
 		return adapted.Scoped(scope, description)

--- a/logger_test.go
+++ b/logger_test.go
@@ -15,8 +15,8 @@ func TestLogger(t *testing.T) {
 	logger, exportLogs := logtest.Captured(t)
 	assert.NotNil(t, logger)
 
-	// If in devmode, the attributes namespace does not get added, but we want to test
-	// that behaviour here so we add it back.
+	// HACK: If in devmode, the attributes namespace does not get added, but we want to
+	// test that behaviour here so we add it back.
 	if globallogger.DevMode() {
 		logger = logger.With(otfields.AttributesNamespace)
 	}


### PR DESCRIPTION
The desired behaviour is:

- in dev, panic if `Scoped` comes before `Init`
- in prod, use a no-op logger if `Scoped` comes before `Init`

Right now it seems the first behaviour never occurs:

- at initialization: `globallogger.devMode = false`
- at illegal `log.Scoped`: devmode is false, return no-op
- at `log.Init`: devmode = true

This means illegal `log.Scoped` usages are never caught. After this change, we catch some illegal logger instantiations:

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/23356519/179849661-ee3ad68e-abb3-4801-b5ff-18ac150915a6.png">

Pretty serious oversight unfortunately 😬 I've found quite a lot of illegal logger initializations we'll need to fix, but for now this we're safe - it just means some logging is silently being discarded without us knowing.