### PR TITLE
log: add SafeScoped logger constructor

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,16 +1,14 @@
 package log
 
 import (
-	"os"
-
 	"github.com/sourcegraph/log/internal/globallogger"
 	"github.com/sourcegraph/log/otfields"
 )
 
-const (
+var (
 	// EnvDevelopment is key of the environment variable that is used to set whether
 	// to use development logger configuration on Init.
-	EnvDevelopment = "SRC_DEVELOPMENT"
+	EnvDevelopment = globallogger.EnvDevelopment
 	// EnvLogLevel is key of the environment variable that is used to set the log format
 	// on Init.
 	EnvLogFormat = "SRC_LOG_FORMAT"
@@ -59,13 +57,11 @@ func Init(r Resource, s ...Sink) *PostInitCallbacks {
 		panic("log.Init initialized multiple times")
 	}
 
-	development := os.Getenv(EnvDevelopment) == "true"
-
-	ss := sinks(append([]Sink{&outputSink{development: development}}, s...))
+	ss := sinks(append([]Sink{&outputSink{development: globallogger.DevMode()}}, s...))
 	cores, sinksBuildErr := ss.build()
 
 	// Init the logger first, so that we can log the error if needed
-	sync := globallogger.Init(r, development, cores)
+	sync := globallogger.Init(r, globallogger.DevMode(), cores)
 
 	if sinksBuildErr != nil {
 		// Log the error

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -1,6 +1,7 @@
 package globallogger
 
 import (
+	"os"
 	"sync"
 
 	"go.uber.org/zap"
@@ -13,7 +14,8 @@ import (
 )
 
 var (
-	devMode          bool
+	EnvDevelopment   = "SRC_DEVELOPMENT"
+	devMode          = os.Getenv(EnvDevelopment) == "true"
 	globalLogger     *zap.Logger
 	globalLoggerInit sync.Once
 )
@@ -36,6 +38,9 @@ func Get(safe bool) *zap.Logger {
 // Init initializes the global logger once. Subsequent calls are no-op. Returns the
 // callback to sync the root core.
 func Init(r otfields.Resource, development bool, sinks []zapcore.Core) func() error {
+	// Update global
+	devMode = development
+
 	globalLoggerInit.Do(func() {
 		globalLogger = initLogger(r, development, sinks)
 	})
@@ -48,9 +53,6 @@ func IsInitialized() bool {
 }
 
 func initLogger(r otfields.Resource, development bool, sinks []zapcore.Core) *zap.Logger {
-	// Set global
-	devMode = development
-
 	internalErrsSink, err := openStderr()
 	if err != nil {
 		panic(err.Error())

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -24,15 +24,15 @@ func DevMode() bool { return devMode }
 
 // Get retrieves the initialized global logger, or panics otherwise (unless safe is true,
 // in which case a no-op logger is returned)
-func Get(safe bool) *zap.Logger {
+func Get(safe bool) (logger *zap.Logger, valid bool) {
 	if !IsInitialized() {
 		if safe {
-			return zap.NewNop()
+			return zap.NewNop(), false
 		} else {
 			panic("global logger not initialized - have you called log.Init or logtest.Init?")
 		}
 	}
-	return globalLogger
+	return globalLogger, true
 }
 
 // Init initializes the global logger once. Subsequent calls are no-op. Returns the

--- a/internal/globallogger/globallogger_test.go
+++ b/internal/globallogger/globallogger_test.go
@@ -13,5 +13,7 @@ func TestGet(t *testing.T) {
 	assert.Panics(t, func() { Get(false) })
 
 	// Uninitialized safe Get should not panic
-	assert.NotNil(t, Get(true))
+	l, ok := Get(true)
+	assert.False(t, ok)
+	assert.NotNil(t, l)
 }

--- a/logger.go
+++ b/logger.go
@@ -83,8 +83,7 @@ type Logger interface {
 // When testing, you should use 'logtest.Scoped(*testing.T)' instead - learn more:
 // https://docs.sourcegraph.com/dev/how-to/add_logging#testing-usage
 func Scoped(scope string, description string) Logger {
-	devMode := globallogger.DevMode()
-	safeGet := !devMode // do not panic in prod
+	safeGet := !globallogger.DevMode() // do not panic in prod
 	root := globallogger.Get(safeGet)
 	adapted := &zapAdapter{
 		Logger:            root,
@@ -92,7 +91,7 @@ func Scoped(scope string, description string) Logger {
 		fromPackageScoped: true,
 	}
 
-	if devMode {
+	if globallogger.DevMode() {
 		// In development, don't add the OpenTelemetry "Attributes" namespace which gets
 		// rather difficult to read.
 		return adapted.Scoped(scope, description)

--- a/logger_test.go
+++ b/logger_test.go
@@ -15,8 +15,8 @@ func TestLogger(t *testing.T) {
 	logger, exportLogs := logtest.Captured(t)
 	assert.NotNil(t, logger)
 
-	// If in devmode, the attributes namespace does not get added, but we want to test
-	// that behaviour here so we add it back.
+	// HACK: If in devmode, the attributes namespace does not get added, but we want to
+	// test that behaviour here so we add it back.
 	if globallogger.DevMode() {
 		logger = logger.With(otfields.AttributesNamespace)
 	}

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -85,7 +85,10 @@ func scopedTestLogger(t testing.TB, options LoggerOptions) log.Logger {
 	Init(nil)
 
 	// On cleanup, flush the global logger.
-	t.Cleanup(func() { globallogger.Get(true).Sync() })
+	t.Cleanup(func() {
+		logger, _ := globallogger.Get(true)
+		logger.Sync()
+	})
 
 	root := log.Scoped(t.Name(), "")
 


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/log/pull/24 - the revelation that we are doing a lot of unsafe `log.Scoped` that are _very_ difficult to disentangle has surfaced a need for a way to:

- create a no-op logger on init
- allow no-op logs to be written
- update the logger instance post-`log.Init`