### PR TITLE
otelfields: make package private, rename to otelfields

### DIFF
--- a/init.go
+++ b/init.go
@@ -2,7 +2,7 @@ package log
 
 import (
 	"github.com/sourcegraph/log/internal/globallogger"
-	"github.com/sourcegraph/log/otfields"
+	"github.com/sourcegraph/log/internal/otelfields"
 )
 
 var (
@@ -28,7 +28,7 @@ var (
 	EnvLogSamplingThereafter = "SRC_LOG_SAMPLING_THEREAFTER"
 )
 
-type Resource = otfields.Resource
+type Resource = otelfields.Resource
 
 // PostInitCallbacks is a set of callbacks returned by Init that enables finalization and
 // updating of any configured sinks.

--- a/internal/encoders/encoders.go
+++ b/internal/encoders/encoders.go
@@ -3,11 +3,11 @@ package encoders
 import (
 	"go.uber.org/zap/zapcore"
 
-	"github.com/sourcegraph/log/otfields"
+	"github.com/sourcegraph/log/internal/otelfields"
 )
 
 type ResourceEncoder struct {
-	otfields.Resource
+	otelfields.Resource
 }
 
 var _ zapcore.ObjectMarshaler = &ResourceEncoder{}
@@ -31,7 +31,7 @@ func (r *ResourceEncoder) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-type TraceContextEncoder struct{ otfields.TraceContext }
+type TraceContextEncoder struct{ otelfields.TraceContext }
 
 var _ zapcore.ObjectMarshaler = &TraceContextEncoder{}
 

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/sourcegraph/log/internal/encoders"
-	"github.com/sourcegraph/log/otfields"
+	"github.com/sourcegraph/log/internal/otelfields"
 )
 
 var (
@@ -37,7 +37,7 @@ func Get(safe bool) *zap.Logger {
 
 // Init initializes the global logger once. Subsequent calls are no-op. Returns the
 // callback to sync the root core.
-func Init(r otfields.Resource, development bool, sinks []zapcore.Core) func() error {
+func Init(r otelfields.Resource, development bool, sinks []zapcore.Core) func() error {
 	// Update global
 	devMode = development
 
@@ -52,7 +52,7 @@ func IsInitialized() bool {
 	return globalLogger != nil
 }
 
-func initLogger(r otfields.Resource, development bool, sinks []zapcore.Core) *zap.Logger {
+func initLogger(r otelfields.Resource, development bool, sinks []zapcore.Core) *zap.Logger {
 	internalErrsSink, err := openStderr()
 	if err != nil {
 		panic(err.Error())
@@ -77,7 +77,7 @@ func initLogger(r otfields.Resource, development bool, sinks []zapcore.Core) *za
 	if r.InstanceID == "" {
 		r.InstanceID = uuid.New().String()
 	}
-	return logger.With(zap.Object(otfields.ResourceFieldKey, &encoders.ResourceEncoder{Resource: r}))
+	return logger.With(zap.Object(otelfields.ResourceFieldKey, &encoders.ResourceEncoder{Resource: r}))
 }
 
 func openStderr() (zapcore.WriteSyncer, error) {

--- a/internal/otelfields/otelfields.go
+++ b/internal/otelfields/otelfields.go
@@ -1,4 +1,4 @@
-package otfields
+package otelfields
 
 import "go.uber.org/zap"
 

--- a/internal/sinkcores/sentrycore/integration_test.go
+++ b/internal/sinkcores/sentrycore/integration_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/internal/configurable"
 	"github.com/sourcegraph/log/internal/encoders"
+	"github.com/sourcegraph/log/internal/otelfields"
 	"github.com/sourcegraph/log/internal/sinkcores/sentrycore"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/sourcegraph/log/otfields"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -95,7 +95,7 @@ func TestTags(t *testing.T) {
 			Name:    "foobar",
 			Version: "123",
 		}
-		logger.Error("msg", log.Error(e), zap.Object(otfields.ResourceFieldKey, &encoders.ResourceEncoder{Resource: resource}))
+		logger.Error("msg", log.Error(e), zap.Object(otelfields.ResourceFieldKey, &encoders.ResourceEncoder{Resource: resource}))
 		sync()
 		assert.Len(t, tr.Events(), 1)
 		assert.Equal(t, tr.Events()[0].Tags["resource.service.name"], "foobar")

--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/getsentry/sentry-go"
 	"github.com/sourcegraph/log/internal/encoders"
-	"github.com/sourcegraph/log/otfields"
+	"github.com/sourcegraph/log/internal/otelfields"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -132,7 +132,7 @@ func (w *worker) capture(errCtx *errorContext) {
 
 	// Extract the service name, if present in the fields.
 	for _, f := range errCtx.Fields {
-		if f.Key == otfields.ResourceFieldKey {
+		if f.Key == otelfields.ResourceFieldKey {
 			if r, ok := f.Interface.(*encoders.ResourceEncoder); ok {
 				tags["resource.service.name"] = r.Name
 				tags["resource.service.version"] = r.Version

--- a/logger.go
+++ b/logger.go
@@ -9,10 +9,13 @@ import (
 
 	"github.com/sourcegraph/log/internal/encoders"
 	"github.com/sourcegraph/log/internal/globallogger"
-	"github.com/sourcegraph/log/otfields"
+	"github.com/sourcegraph/log/internal/otelfields"
 )
 
-type TraceContext = otfields.TraceContext
+// TraceContext represents a trace to associate with log entries.
+//
+// https://opentelemetry.io/docs/reference/specification/logs/data-model/#trace-context-fields
+type TraceContext = otelfields.TraceContext
 
 // Logger is an OpenTelemetry-compliant logger. All functions that log output should hold
 // a reference to a Logger that gets passed in from callers, so as to maintain fields and
@@ -96,7 +99,7 @@ func Scoped(scope string, description string) Logger {
 		// rather difficult to read.
 		return adapted.Scoped(scope, description)
 	}
-	return adapted.Scoped(scope, description).With(otfields.AttributesNamespace)
+	return adapted.Scoped(scope, description).With(otelfields.AttributesNamespace)
 }
 
 type zapAdapter struct {

--- a/logger_test.go
+++ b/logger_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/internal/globallogger"
+	"github.com/sourcegraph/log/internal/otelfields"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/sourcegraph/log/otfields"
 )
 
 func TestLogger(t *testing.T) {
@@ -18,7 +18,7 @@ func TestLogger(t *testing.T) {
 	// HACK: If in devmode, the attributes namespace does not get added, but we want to
 	// test that behaviour here so we add it back.
 	if globallogger.DevMode() {
-		logger = logger.With(otfields.AttributesNamespace)
+		logger = logger.With(otelfields.AttributesNamespace)
 	}
 
 	logger.Debug("a debug message") // 0

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/log/internal/globallogger"
 	"github.com/sourcegraph/log/internal/sinkcores/outputcore"
 	"github.com/sourcegraph/log/internal/stderr"
-	"github.com/sourcegraph/log/otfields"
 )
 
 // stdTestInit guards the initialization of the standard library testing package.
@@ -61,7 +60,7 @@ func initGlobal(level zapcore.Level) {
 	}
 	core := outputcore.NewDevelopmentCore(output, level, encoders.OutputConsole)
 	// use an empty resource, we don't log output Resource in dev mode anyway
-	globallogger.Init(otfields.Resource{}, true, []zapcore.Core{core})
+	globallogger.Init(log.Resource{}, true, []zapcore.Core{core})
 }
 
 type CapturedLog struct {


### PR DESCRIPTION
ot = opentracing, otel = opentelemetry - similar to https://github.com/sourcegraph/sourcegraph/pull/39464