### PR TITLE
re-apply "#24: log: fix devmode and safe logger instantiation"

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,16 +1,14 @@
 package log
 
 import (
-	"os"
-
 	"github.com/sourcegraph/log/internal/globallogger"
 	"github.com/sourcegraph/log/internal/otelfields"
 )
 
-const (
+var (
 	// EnvDevelopment is key of the environment variable that is used to set whether
 	// to use development logger configuration on Init.
-	EnvDevelopment = "SRC_DEVELOPMENT"
+	EnvDevelopment = globallogger.EnvDevelopment
 	// EnvLogLevel is key of the environment variable that is used to set the log format
 	// on Init.
 	EnvLogFormat = "SRC_LOG_FORMAT"
@@ -59,13 +57,11 @@ func Init(r Resource, s ...Sink) *PostInitCallbacks {
 		panic("log.Init initialized multiple times")
 	}
 
-	development := os.Getenv(EnvDevelopment) == "true"
-
-	ss := sinks(append([]Sink{&outputSink{development: development}}, s...))
+	ss := sinks(append([]Sink{&outputSink{development: globallogger.DevMode()}}, s...))
 	cores, sinksBuildErr := ss.build()
 
 	// Init the logger first, so that we can log the error if needed
-	sync := globallogger.Init(r, development, cores)
+	sync := globallogger.Init(r, globallogger.DevMode(), cores)
 
 	if sinksBuildErr != nil {
 		// Log the error

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	devMode          bool
+	EnvDevelopment   = "SRC_DEVELOPMENT"
+	devMode          = os.Getenv(EnvDevelopment) == "true"
 	globalLogger     *zap.Logger
 	globalLoggerInit sync.Once
 )
@@ -37,6 +38,9 @@ func Get(safe bool) *zap.Logger {
 // Init initializes the global logger once. Subsequent calls are no-op. Returns the
 // callback to sync the root core.
 func Init(r otelfields.Resource, development bool, sinks []zapcore.Core) func() error {
+	// Update global
+	devMode = development
+
 	globalLoggerInit.Do(func() {
 		globalLogger = initLogger(r, development, sinks)
 	})
@@ -67,9 +71,6 @@ func (f *forceSyncer) OnWrite(_ *zapcore.CheckedEntry, _ []zapcore.Field) {
 }
 
 func initLogger(r otelfields.Resource, development bool, sinks []zapcore.Core) *zap.Logger {
-	// Set global
-	devMode = development
-
 	internalErrsSink, err := openStderr()
 	if err != nil {
 		panic(err.Error())

--- a/logger.go
+++ b/logger.go
@@ -87,8 +87,7 @@ type Logger interface {
 // When testing, you should use 'logtest.Scoped(*testing.T)' instead - learn more:
 // https://docs.sourcegraph.com/dev/how-to/add_logging#testing-usage
 func Scoped(scope string, description string) Logger {
-	devMode := globallogger.DevMode()
-	safeGet := !devMode // do not panic in prod
+	safeGet := !globallogger.DevMode() // do not panic in prod
 	root := globallogger.Get(safeGet)
 	adapted := &zapAdapter{
 		Logger:            root,
@@ -96,7 +95,7 @@ func Scoped(scope string, description string) Logger {
 		fromPackageScoped: true,
 	}
 
-	if devMode {
+	if globallogger.DevMode() {
 		// In development, don't add the OpenTelemetry "Attributes" namespace which gets
 		// rather difficult to read.
 		return adapted.Scoped(scope, description)

--- a/logger_test.go
+++ b/logger_test.go
@@ -15,8 +15,8 @@ func TestLogger(t *testing.T) {
 	logger, exportLogs := logtest.Captured(t)
 	assert.NotNil(t, logger)
 
-	// If in devmode, the attributes namespace does not get added, but we want to test
-	// that behaviour here so we add it back.
+	// HACK: If in devmode, the attributes namespace does not get added, but we want to
+	// test that behaviour here so we add it back.
 	if globallogger.DevMode() {
 		logger = logger.With(otelfields.AttributesNamespace)
 	}


### PR DESCRIPTION
This reverts commit e94dc0c4d111999b24c0649e5a33ffd38cb3748f.

This re-applies https://github.com/sourcegraph/log/pull/24