### PR TITLE
remove merge of default client opts

### DIFF
--- a/internal/sinkcores/sentrycore/default_sentry_client_opts.go
+++ b/internal/sinkcores/sentrycore/default_sentry_client_opts.go
@@ -7,11 +7,3 @@ import "github.com/getsentry/sentry-go"
 var DefaultSentryClientOptions = sentry.ClientOptions{
 	SampleRate: 0.1,
 }
-
-// ApplySentryClientDefaultOptions merges opts with the defaults defined in DefaultSentryClientOptions.
-func ApplySentryClientDefaultOptions(opts sentry.ClientOptions) sentry.ClientOptions {
-	if opts.SampleRate == 0 {
-		opts.SampleRate = DefaultSentryClientOptions.SampleRate
-	}
-	return opts
-}

--- a/sinks_sentry.go
+++ b/sinks_sentry.go
@@ -31,7 +31,6 @@ func NewSentrySink() Sink {
 }
 
 // NewSentrySinkWith instantiates a Sentry sink to provide to `log.Init` with the values provided in SentrySink.
-// Default values are set if they do not exist in the given sink
 func NewSentrySinkWith(s SentrySink) Sink {
 	return &sentrySink{SentrySink: SentrySink{s.ClientOptions}}
 }

--- a/sinks_sentry.go
+++ b/sinks_sentry.go
@@ -33,8 +33,7 @@ func NewSentrySink() Sink {
 // NewSentrySinkWith instantiates a Sentry sink to provide to `log.Init` with the values provided in SentrySink.
 // Default values are set if they do not exist in the given sink
 func NewSentrySinkWith(s SentrySink) Sink {
-	opts := sentrycore.ApplySentryClientDefaultOptions(s.ClientOptions)
-	return &sentrySink{SentrySink: SentrySink{opts}}
+	return &sentrySink{SentrySink: SentrySink{s.ClientOptions}}
 }
 
 func (s *sentrySink) Name() string { return "SentrySink" }


### PR DESCRIPTION
This removes the auto merged of default values into the provided client options. Sometimes you really want to set certain values and don't want defaults applied.

If users want defaults, the no arg constructor uses `DefaultSentryClientOptions`.