### PR TITLE
add forceSyncer on log inititalization to force Sync cores

### DIFF
--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -49,6 +49,8 @@ func IsInitialized() bool {
 }
 
 // forceSyncer implements the zapcore.CheckWriteHook interface and ensures that sync is called on the provided core.
+// By adding it as a option with zap.WithFatalHook to the logger options, it will ensure Sync is called when a Fatal
+// log is issued.
 // As per the advice from https://pkg.go.dev/go.uber.org/zap#WithFatalHook, os.Exit(1) is called to halt execution after
 // Sync has completed
 type forceSyncer struct {
@@ -57,9 +59,10 @@ type forceSyncer struct {
 
 var _ zapcore.CheckWriteHook = &forceSyncer{}
 
-// OnWrite calls sync on the underlying core and then calls os.Exit(1)
+// OnWrite calls sync on the underlying core and then calls os.Exit(1).
 func (f *forceSyncer) OnWrite(_ *zapcore.CheckedEntry, _ []zapcore.Field) {
-	f.core.Sync()
+	// We ignore the error here, since we're just making sure all cores have synced before exiting
+	_ = f.core.Sync()
 	os.Exit(1)
 }
 

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -50,7 +50,7 @@ func IsInitialized() bool {
 
 // forceSyncer implements the zapcore.CheckWriteHook interface and ensures that sync is called on the provided core.
 // As per the advice from https://pkg.go.dev/go.uber.org/zap#WithFatalHook, os.Exit(1) is called to halt execution after
-// Sync has compelted
+// Sync has completed
 type forceSyncer struct {
 	core zapcore.Core
 }

--- a/internal/globallogger/globallogger.go
+++ b/internal/globallogger/globallogger.go
@@ -1,6 +1,7 @@
 package globallogger
 
 import (
+	"os"
 	"sync"
 
 	"go.uber.org/zap"
@@ -47,15 +48,19 @@ func IsInitialized() bool {
 	return globalLogger != nil
 }
 
-// forceSyncer implements the zapcore.CheckWriteHook interface and ensures that sync is called on the provided core
+// forceSyncer implements the zapcore.CheckWriteHook interface and ensures that sync is called on the provided core.
+// As per the advice from https://pkg.go.dev/go.uber.org/zap#WithFatalHook, os.Exit(1) is called to halt execution after
+// Sync has compelted
 type forceSyncer struct {
 	core zapcore.Core
 }
 
 var _ zapcore.CheckWriteHook = &forceSyncer{}
 
+// OnWrite calls sync on the underlying core and then calls os.Exit(1)
 func (f *forceSyncer) OnWrite(_ *zapcore.CheckedEntry, _ []zapcore.Field) {
 	f.core.Sync()
+	os.Exit(1)
 }
 
 func initLogger(r otelfields.Resource, development bool, sinks []zapcore.Core) *zap.Logger {


### PR DESCRIPTION
zapcore v1.22 added `WithFatalHook` which allows one to execute some custom code after a Fatal log. We add a forceSyncer which force calls Sync on the underlying core before halting execution as per the advice from https://pkg.go.dev/go.uber.org/zap#WithFatalHook

### Test plan
Manual testing