### PR TITLE
export type aliased sentry.ClientOptions as SentryClientOptions and simplify NewSentrySinkWith

### DIFF
--- a/sinks_sentry.go
+++ b/sinks_sentry.go
@@ -15,7 +15,7 @@ type SentryClientOptions = sentry.ClientOptions
 // complete with stacktrace data and any additional context logged in the corresponding
 // log message (including anything accumulated on a sub-logger).
 type SentrySink struct {
-	// ClientOptions expose various options to configure the Sentry client
+	// SentryClientOptions expose various options to configure the Sentry client
 	SentryClientOptions
 }
 


### PR DESCRIPTION
With previous work, `sentry.ClientOptions` got embded into a SentrySink, but this "complicates" creation of the sink with quite a lot of stuttering. It also required an explicit import of `sentry-go`.
Example
```go
liblog := log.Init(log.Resource{
  Name:       "I am an example",
  Version:    "-",
  InstanceID: hostname.Get(),
}, log.NewSentrySinkWith(
    log.SentrySink{
    ClientOptions: sentryllib.ClientOptions{
	    Debug:      true,
	    Dsn:        dsn,
	    SampleRate: 1,
    },
}))
```
By createa a type alias for `sentry.ClientOptions` and exporting as `SentryClientOptions` users of the log package do not have to import `sentry-go`. Additionally, changing the `NewSentrySinkWith` constructor to take in `SentryClientOptions` instead of a SentrySink simplifies the SentrySink instantiation.
Example:
```go
liblog := log.Init(log.Resource{
  Name:       "I am an example",
  Version:    "-",
  InstanceID: hostname.Get(),
}, log.NewSentrySinkWith(
    log.SentryClientOptions{
	    Debug:      true,
	    Dsn:        dsn,
	    SampleRate: 1, 
    },
))
```