### PR TITLE
log: add a native NoOp logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -104,6 +104,17 @@ func Scoped(scope string, description string) Logger {
 	return adapted.Scoped(scope, description).With(otelfields.AttributesNamespace)
 }
 
+// NoOp returns a no-op Logger that can never produce any output. It can be safely created
+// before initialization. Use sparingly, and do not use with the intent of replacing it
+// post-initialization.
+func NoOp() Logger {
+	root := zap.NewNop()
+	return &zapAdapter{
+		Logger:     root,
+		rootLogger: root,
+	}
+}
+
 type zapAdapter struct {
 	*zap.Logger
 

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -152,6 +152,6 @@ func Captured(t testing.TB) (logger log.Logger, exportLogs func() []CapturedLog)
 }
 
 // NoOp returns a no-op Logger, useful for silencing all output in a specific test.
-func NoOp(t *testing.T) log.Logger {
-	return Scoped(t).IncreaseLevel("noop", "no-op logger", log.LevelNone)
+func NoOp(_ *testing.T) log.Logger {
+	return log.NoOp()
 }


### PR DESCRIPTION
Adding as part of investigations into how we can introduce #28 safely into `sourcegraph/sourcegraph`. Some parts of the codebase (`TestContext`) really needs a truly no-op logger that can be provided before initialization, so we added a `NoOp` constructor and hope it does not get misused.