### PR TITLE
Audit Log

### DIFF
--- a/auditlog.go
+++ b/auditlog.go
@@ -6,8 +6,6 @@ type Actor struct {
 	ForwardedFor string
 }
 
-//TODO describe the 'actor takes an action on entity' idea
-
 func (z *zapAdapter) Audit(actor Actor, action string, fields ...Field) {
 	fields = append(fields, String("audit", "true"))
 

--- a/auditlog.go
+++ b/auditlog.go
@@ -1,9 +1,9 @@
 package log
 
 type Actor struct {
-	actorUID     string
-	ip           string
-	forwardedFor string
+	ActorUID      string
+	Ip            string
+	XForwardedFor string
 }
 
 //TODO describe the 'actor takes an action on entity' idea
@@ -12,9 +12,9 @@ func (z *zapAdapter) Audit(actor Actor, action string, fields ...Field) {
 	fields = append(fields, String("audit", "true"))
 
 	fields = append(fields, Object("audit.actor",
-		String("actorUID", actor.actorUID),
-		String("ip", actor.ip),
-		String("X-Forwarded-For", actor.forwardedFor)))
+		String("actorUID", actor.ActorUID),
+		String("ip", actor.Ip),
+		String("X-Forwarded-For", actor.XForwardedFor)))
 	fields = append(fields, String("audit.action", action))
 	fields = append(fields, String("audit.entity", z.fullScope))
 

--- a/auditlog.go
+++ b/auditlog.go
@@ -1,0 +1,22 @@
+package log
+
+type Actor struct {
+	actorUID     string
+	ip           string
+	forwardedFor string
+}
+
+//TODO describe the 'actor takes an action on entity' idea
+
+func (z *zapAdapter) Audit(actor Actor, action string, fields ...Field) {
+	fields = append(fields, String("audit", "true"))
+
+	fields = append(fields, Object("audit.actor",
+		String("actorUID", actor.actorUID),
+		String("ip", actor.ip),
+		String("X-Forwarded-For", actor.forwardedFor)))
+	fields = append(fields, String("audit.action", action))
+	fields = append(fields, String("audit.entity", z.fullScope))
+
+	z.Info("audit action", fields...)
+}

--- a/auditlog.go
+++ b/auditlog.go
@@ -1,9 +1,9 @@
 package log
 
 type Actor struct {
-	ActorUID      string
-	Ip            string
-	XForwardedFor string
+	ActorUID     string
+	IP           string
+	ForwardedFor string
 }
 
 //TODO describe the 'actor takes an action on entity' idea
@@ -13,8 +13,8 @@ func (z *zapAdapter) Audit(actor Actor, action string, fields ...Field) {
 
 	fields = append(fields, Object("audit.actor",
 		String("actorUID", actor.ActorUID),
-		String("ip", actor.Ip),
-		String("X-Forwarded-For", actor.XForwardedFor)))
+		String("ip", actor.IP),
+		String("X-Forwarded-For", actor.ForwardedFor)))
 	fields = append(fields, String("audit.action", action))
 	fields = append(fields, String("audit.entity", z.fullScope))
 

--- a/logger.go
+++ b/logger.go
@@ -51,6 +51,11 @@ type Logger interface {
 	//
 	// Info is the default logging priority.
 	Info(string, ...Field)
+
+	// Audit logs an info message, including any fields accumulated on the Logger.
+	// Additionally, Audit appends an "audit": "true" to the Attributes map so that it is easily recognizable by the audit log consumer.
+	Audit(string, ...Field)
+
 	// Warn logs a message at WarnLevel, including any fields accumulated on the Logger.
 	//
 	// Warning logs are more important than Info, but don't need individual human review.
@@ -243,6 +248,11 @@ func (z *zapAdapter) WithCore(f func(c zapcore.Core) zapcore.Core) Logger {
 		fullScope:  z.fullScope,
 		attributes: z.attributes,
 	}
+}
+
+func (z *zapAdapter) Audit(message string, field ...Field) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func createScope(parent, child string) string {

--- a/logger.go
+++ b/logger.go
@@ -53,7 +53,8 @@ type Logger interface {
 	Info(string, ...Field)
 
 	// Audit logs an info message, including any fields accumulated on the Logger.
-	// Additionally, Audit appends an "audit": "true" to the Attributes map so that it is easily recognizable by the audit log consumer.
+	// Additionally, Audit appends several fields to the Attributes map so that it is easily recognizable by the audit log consumer.
+	// Fields appended: audit, audit.actor (with nested fields), audit.action, audit.entity.
 	Audit(actor Actor, action string, fields ...Field)
 
 	// Warn logs a message at WarnLevel, including any fields accumulated on the Logger.

--- a/logger.go
+++ b/logger.go
@@ -54,7 +54,7 @@ type Logger interface {
 
 	// Audit logs an info message, including any fields accumulated on the Logger.
 	// Additionally, Audit appends an "audit": "true" to the Attributes map so that it is easily recognizable by the audit log consumer.
-	Audit(string, ...Field)
+	Audit(actor Actor, action string, fields ...Field)
 
 	// Warn logs a message at WarnLevel, including any fields accumulated on the Logger.
 	//
@@ -248,11 +248,6 @@ func (z *zapAdapter) WithCore(f func(c zapcore.Core) zapcore.Core) Logger {
 		fullScope:  z.fullScope,
 		attributes: z.attributes,
 	}
-}
-
-func (z *zapAdapter) Audit(message string, fields ...Field) {
-	fields = append(fields, String("audit", "true"))
-	z.Info(message, fields...)
 }
 
 func createScope(parent, child string) string {

--- a/logger.go
+++ b/logger.go
@@ -250,9 +250,9 @@ func (z *zapAdapter) WithCore(f func(c zapcore.Core) zapcore.Core) Logger {
 	}
 }
 
-func (z *zapAdapter) Audit(message string, field ...Field) {
-	//TODO implement me
-	panic("implement me")
+func (z *zapAdapter) Audit(message string, fields ...Field) {
+	fields = append(fields, String("audit", "true"))
+	z.Info(message, fields...)
 }
 
 func createScope(parent, child string) string {


### PR DESCRIPTION
### Description

This expands our standard logging library with auditing capabilities. The idea is that moving an entry to the "audit log" means just using the tools we have with additional metadata.

For more details, see the following:
- [RFC 732](https://docs.google.com/document/d/12x09FhwKz4hS-r__kPqn8k5pcnhJ_Iy3DHt7p6OKQcY/edit)
- [RFC 734](https://docs.google.com/document/d/1tv1wNxfqtg4qfJ6jhbd9rFMIt1JCEjGEFzvV5j_i-sI/edit#heading=h.trqab8y0kufp)

The new `(Logger).Audit` call is a special flavor of `Info` call that enriches the standard INFO log statement with a few extra fields:

```json
{
  "SeverityText": "INFO",
  "Timestamp": 1662061536700202000,
  "InstrumentationScope": "NewClient.testing-stuff",
  "Caller": "log/auditlog.go:19",
  "Function": "github.com/sourcegraph/log.(*zapAdapter).Audit",
  "Body": "audit action",
  "Resource": {
    "service.name": "frontend",
    "service.version": "0.0.0+dev",
    "service.instance.id": "Michals-MacBook-Pro.local"
  },
  "Attributes": {
    "audit": "true",
    "audit.actor": {
      "actorUID": "\u0001",
      "ip": "127.0.0.1",
      "X-Forwarded-For": "127.0.0.1, 127.0.0.1"
    },
    "audit.action": "GetObject called",
    "audit.entity": "NewClient.testing-stuff"
  }
}
```

We can filter the audit log statements by the presence of `audit` attribute in the `Attributes` map.

Sample usage:

```
	act := actor.FromContext(ctx)
	cli := requestclient.FromContext(ctx)
        logger := c.logger.Scoped("testing-stuff", "structured logging")
	logger.Audit(sglog.Actor{string(act.UID), cli.IP, cli.ForwardedFor}, "GetObject called")
```
### Design

- audit log builds on top of our existing logging, so that we don't need to think twice about using yet another library along our standard logging, and instrumentation libraries
- an audit log entry should read like: "**an actor takes an action on entity**"
  - an actor is the caller
  - an action is any arbitrary human-readable string
  - entity is inferred from the logger scope (which already defines the component)

### Other options considered

I originally thought that it's better to add a new severity level (`AUDIT`), but since our logging library is primarily an adapter for Zap this felt less idiomatic and way hackier.

### Next steps

- transform gitserver access logs to audit calls
- transform graphql request logs to audit calls
- tee security events inserts to audit calls

## Questions
- What's the best way of marking this API is experimental? I reckon the design will change once we start using it more widely ...
- Is inferring the audited entity name by looking at the logger scope good enough? Should we be able to pass it into the `Audit()` call instead?
- Are there any naming conventions for keys in the `Attributes` map?
