### PR TITLE
sentrycore: support all resource tags

### DIFF
--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -135,7 +135,15 @@ func (w *worker) capture(errCtx *errorContext) {
 		if f.Key == otelfields.ResourceFieldKey {
 			if r, ok := f.Interface.(*encoders.ResourceEncoder); ok {
 				tags["resource.service.name"] = r.Name
-				tags["resource.service.version"] = r.Version
+				if r.Version != "" {
+					tags["resource.service.version"] = r.Version
+				}
+				if r.Namespace != "" {
+					tags["resource.service.namespace"] = r.Namespace
+				}
+				if r.InstanceID != "" {
+					tags["resource.service.instance.id"] = r.InstanceID
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In the cla-bot sync tool I want to use `instance.id` as a tag to indicate the workflow run, but right now they are only treated as extra attributes. This adds all the resource fields as tags _if_ they are set.