### PR TITLE
Sync from Init suppresses error

### DIFF
--- a/init.go
+++ b/init.go
@@ -36,7 +36,11 @@ type Resource = otelfields.Resource
 // updating of any configured sinks.
 type PostInitCallbacks struct {
 	// Sync must be called before application exit, such as via defer.
-	Sync func() error
+	//
+	// Note: The error from sync is suppressed since this is usually called as a
+	// defer in func main. In that case there isn't a reasonable way to handle the
+	// error. As such this function signature doesn't return an error.
+	Sync func()
 
 	// Update should be called to change sink configuration, e.g. via
 	// conf.Watch. Note that sinks not created upon initialization will
@@ -79,7 +83,7 @@ func Init(r Resource, s ...Sink) *PostInitCallbacks {
 	}
 
 	return &PostInitCallbacks{
-		Sync:   sync,
+		Sync:   func() { _ = sync() },
 		Update: ss.update,
 	}
 }


### PR DESCRIPTION
In practice (and in documentation) no one checks the error returned from `liblog.Sync()`. Searching sourcegraph repos for [`log.Sync()`](https://sourcegraph.com/search?q=context:%40sourcegraph/all+log.Sync%28%29&patternType=standard) has 22 results, all of which ignore the returned error.

This commit removes the error return to make this explicit. Additionally this will remove the "errcheck" linter complaining about all these call sites.

Note: When updating sourcegraph there is one callsite which explicitly ignores the error return which will need updating. https://github.com/sourcegraph/sourcegraph/blob/93bc1093d7169bba30ba6387ae4bb30cd2171f55/dev/sg/main.go#L210

Test Plan: go test
