### PR TITLE
sink: fix docstring typo

### DIFF
--- a/sinks.go
+++ b/sinks.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Sink describes additional destinations that github.com/sourcegraph/log can send log
-// entries to. It can only be implmented directly within the package.
+// entries to. It can only be implemented directly within the package.
 type Sink interface {
 	Name() string
 


### PR DESCRIPTION
Fix a typo