### PR TITLE
introduce SRC_LOG_SCOPE_LEVEL

### DIFF
--- a/init.go
+++ b/init.go
@@ -22,10 +22,15 @@ var (
 	//
 	// It has the format "SCOPE_0=LEVEL_0,SCOPE_1=LEVEL_1,...".
 	//
-	// Note: these levels do not respect the root level (SRC_LOG_LEVEL), so this
-	// allows operators to turn up the verbosity of specific logs.
+	// Notes:
 	//
-	// Note: this only affects the outputcore (ie will not effect sentrycore).
+	//  - these levels do not respect the root level (SRC_LOG_LEVEL), so this
+	//    allows operators to turn up the verbosity of specific logs.
+	//  - this only affects the outputcore (ie will not effect sentrycore).
+	//  - Scope matches the full scope name. IE the below example has the scope
+	//    "foo.bar" not "bar".
+	//
+	//    log.Scoped("foo", "").Scoped("bar", "")
 	EnvLogScopeLevel = "SRC_LOG_SCOPE_LEVEL"
 	// EnvLogSamplingInitial is key of the environment variable that can be used to set
 	// the number of entries with identical messages to always output per second.

--- a/init.go
+++ b/init.go
@@ -24,6 +24,8 @@ var (
 	//
 	// Note: these levels do not respect the root level (SRC_LOG_LEVEL), so this
 	// allows operators to turn up the verbosity of specific logs.
+	//
+	// Note: this only affects the outputcore (ie will not effect sentrycore).
 	EnvLogScopeLevel = "SRC_LOG_SCOPE_LEVEL"
 	// EnvLogSamplingInitial is key of the environment variable that can be used to set
 	// the number of entries with identical messages to always output per second.

--- a/init.go
+++ b/init.go
@@ -17,6 +17,14 @@ var (
 	// EnvLogLevel is key of the environment variable that can be used to set the log
 	// level on Init.
 	EnvLogLevel = "SRC_LOG_LEVEL"
+	// EnvLogScopeLevel is key of the environment variable that can be used to
+	// override the log level for specific scopes and its children.
+	//
+	// It has the format "SCOPE_0=LEVEL_0,SCOPE_1=LEVEL_1,...".
+	//
+	// Note: these levels do not respect the root level (SRC_LOG_LEVEL), so this
+	// allows operators to turn up the verbosity of specific logs.
+	EnvLogScopeLevel = "SRC_LOG_SCOPE_LEVEL"
 	// EnvLogSamplingInitial is key of the environment variable that can be used to set
 	// the number of entries with identical messages to always output per second.
 	//

--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -1,21 +1,12 @@
 package outputcore
 
 import (
-	"strings"
 	"time"
 
 	"github.com/sourcegraph/log/internal/encoders"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
-
-// Override allows adjusting the log level for specific scopes.
-type Override struct {
-	// Scope matches any zapcore.Entry with the name Scope or the prefix Scope + ".".
-	Scope string
-	// Level is the level to log at for zapcore.Entry's that match Scope.
-	Level zapcore.Level
-}
 
 func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig, overrides []Override) zapcore.Core {
 	newCore := func(level zapcore.LevelEnabler) zapcore.Core {
@@ -32,83 +23,4 @@ func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format enco
 		return zapcore.NewSamplerWithOptions(core, time.Second, sampling.Initial, sampling.Thereafter)
 	}
 	return core
-}
-
-// newOverrideCore will create a core with the specific overrides. newCore is
-// required because we need to adjust the level to allow the overrides to log.
-func newOverrideCore(level zapcore.LevelEnabler, overrides []Override, newCore func(zapcore.LevelEnabler) zapcore.Core) zapcore.Core {
-	// We need to adjust level we construct NewCore such that if a level is
-	// overriden we end up logging it.
-	minOverrideLevel := level
-	for _, o := range overrides {
-		if !minOverrideLevel.Enabled(o.Level) {
-			minOverrideLevel = o.Level
-		}
-	}
-
-	core := newCore(minOverrideLevel)
-
-	// Only use overrideCore if it could have an effect.
-	if minOverrideLevel == level {
-		return core
-	}
-
-	return &overrideCore{
-		Core:      core,
-		level:     level,
-		overrides: overrides,
-	}
-}
-
-// overrideCore wraps a core to additionally log a message if it matches
-// overrides or level.
-type overrideCore struct {
-	// Core is the wrapped core. Note its level must be lowered such that if a
-	// message matches an override it will be logged. Then we gate everything
-	// else with level.
-	zapcore.Core
-
-	// level is the passed in level before Core was lowered to take into account
-	// the overrides.
-	level zapcore.LevelEnabler
-
-	overrides []Override
-}
-
-func (c *overrideCore) Level() zapcore.Level {
-	return zapcore.LevelOf(c.Core)
-}
-
-func (c *overrideCore) With(fields []zapcore.Field) zapcore.Core {
-	return &overrideCore{
-		Core:      c.Core.With(fields),
-		level:     c.level,
-		overrides: c.overrides,
-	}
-}
-
-func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if c.level.Enabled(ent.Level) {
-		return c.Core.Check(ent, ce)
-	}
-
-	if !c.Core.Enabled(ent.Level) {
-		return ce
-	}
-
-	for _, o := range c.overrides {
-		if !strings.HasPrefix(ent.LoggerName, o.Scope) {
-			continue
-		}
-		// Check that if o.Scope != ent.LoggerName then it is a child logger
-		if len(ent.LoggerName) > len(o.Scope) && ent.LoggerName[len(o.Scope)] != '.' {
-			continue
-		}
-
-		if o.Level.Enabled(ent.Level) {
-			return c.Core.Check(ent, ce)
-		}
-	}
-
-	return ce
 }

--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -1,6 +1,7 @@
 package outputcore
 
 import (
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/log/internal/encoders"
@@ -8,15 +9,130 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig) zapcore.Core {
-	core := zapcore.NewCore(
-		encoders.BuildEncoder(format, false),
-		output,
-		level,
-	)
+// Override allows adjusting the log level for specific scopes.
+type Override struct {
+	// Scope matches any zapcore.Entry with the name Scope or the prefix Scope + ".".
+	Scope string
+	// Level is the level to log at for zapcore.Entry's that match Scope.
+	Level zapcore.Level
+}
+
+func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig, overrides []Override) zapcore.Core {
+	minOverrideLevel := level
+	for _, o := range overrides {
+		if !minOverrideLevel.Enabled(o.Level) {
+			minOverrideLevel = o.Level
+		}
+	}
+
+	core := &overrideCore{
+		enc: encoders.BuildEncoder(format, false),
+		out: output,
+
+		level:            level,
+		minOverrideLevel: minOverrideLevel,
+
+		overrides: overrides,
+	}
 
 	if sampling.Initial > 0 {
 		return zapcore.NewSamplerWithOptions(core, time.Second, sampling.Initial, sampling.Thereafter)
 	}
 	return core
+}
+
+// override is a zapcore.Core and zapcore.LevelEnabler which additionally
+// will logs entries were allow returns true no matter the level.
+//
+// This does not wrap another core since that would not allow us to override
+// that core's level. It is mostly copy pasta of zapcore.ioCore
+type overrideCore struct {
+	enc zapcore.Encoder
+	out zapcore.WriteSyncer
+
+	// level is the passed in level
+	level zapcore.LevelEnabler
+
+	// minOverrideLevel is the most verbose level we could log at. We have to
+	// return this level as part of our interface since if we have any child
+	// cores they can check directly against us via Enabled.
+	minOverrideLevel zapcore.LevelEnabler
+
+	overrides []Override
+}
+
+func (c *overrideCore) Enabled(l zapcore.Level) bool {
+	return c.minOverrideLevel.Enabled(l)
+}
+
+func (c *overrideCore) Level() zapcore.Level {
+	return zapcore.LevelOf(c.minOverrideLevel)
+}
+
+func (c *overrideCore) With(fields []zapcore.Field) zapcore.Core {
+	clone := c.clone()
+	for i := range fields {
+		fields[i].AddTo(c.enc)
+	}
+	return clone
+}
+
+func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.level.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+
+	if !c.minOverrideLevel.Enabled(ent.Level) {
+		return ce
+	}
+
+	for _, o := range c.overrides {
+		if !strings.HasPrefix(ent.LoggerName, o.Scope) {
+			continue
+		}
+		// Check that if o.Scope != ent.LoggerName then it is a child logger
+		if len(ent.LoggerName) > len(o.Scope) && ent.LoggerName[len(o.Scope)] != '.' {
+			continue
+		}
+
+		if o.Level.Enabled(ent.Level) {
+			return ce.AddCore(ent, c)
+		}
+	}
+
+	return ce
+}
+
+func (c *overrideCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	buf, err := c.enc.EncodeEntry(ent, fields)
+	if err != nil {
+		return err
+	}
+	_, err = c.out.Write(buf.Bytes())
+	buf.Free()
+	if err != nil {
+		return err
+	}
+	if ent.Level > zapcore.ErrorLevel {
+		// Since we may be crashing the program, sync the output. Ignore Sync
+		// errors, pending a clean solution to issue #370.
+		c.Sync()
+	}
+	return nil
+}
+
+func (c *overrideCore) Sync() error {
+	return c.out.Sync()
+}
+
+func (c *overrideCore) clone() *overrideCore {
+	return &overrideCore{
+		enc: c.enc.Clone(),
+		out: c.out,
+
+		level:            c.level,
+		minOverrideLevel: c.minOverrideLevel,
+
+		overrides: c.overrides,
+	}
 }

--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -18,6 +18,8 @@ type Override struct {
 }
 
 func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig, overrides []Override) zapcore.Core {
+	// We need to adjust level we construct NewCore such that if a level is
+	// overriden we end up logging it.
 	minOverrideLevel := level
 	for _, o := range overrides {
 		if !minOverrideLevel.Enabled(o.Level) {
@@ -25,14 +27,19 @@ func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format enco
 		}
 	}
 
-	core := &overrideCore{
-		enc: encoders.BuildEncoder(format, false),
-		out: output,
+	core := zapcore.NewCore(
+		encoders.BuildEncoder(format, false),
+		output,
+		minOverrideLevel,
+	)
 
-		level:            level,
-		minOverrideLevel: minOverrideLevel,
-
-		overrides: overrides,
+	// Only use overrideCore if it could have an effect.
+	if minOverrideLevel != level {
+		core = &overrideCore{
+			Core:      core,
+			level:     level,
+			overrides: overrides,
+		}
 	}
 
 	if sampling.Initial > 0 {
@@ -41,48 +48,39 @@ func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format enco
 	return core
 }
 
-// override is a zapcore.Core and zapcore.LevelEnabler which additionally
-// will logs entries were allow returns true no matter the level.
-//
-// This does not wrap another core since that would not allow us to override
-// that core's level. It is mostly copy pasta of zapcore.ioCore
+// overrideCore wraps a core to additionally log a message if it matches
+// overrides or level.
 type overrideCore struct {
-	enc zapcore.Encoder
-	out zapcore.WriteSyncer
+	// Core is the wrapped core. Note its level must be lowered such that if a
+	// message matches an override it will be logged. Then we gate everything
+	// else with level.
+	zapcore.Core
 
-	// level is the passed in level
+	// level is the passed in level before Core was lowered to take into account
+	// the overrides.
 	level zapcore.LevelEnabler
-
-	// minOverrideLevel is the most verbose level we could log at. We have to
-	// return this level as part of our interface since if we have any child
-	// cores they can check directly against us via Enabled.
-	minOverrideLevel zapcore.LevelEnabler
 
 	overrides []Override
 }
 
-func (c *overrideCore) Enabled(l zapcore.Level) bool {
-	return c.minOverrideLevel.Enabled(l)
-}
-
 func (c *overrideCore) Level() zapcore.Level {
-	return zapcore.LevelOf(c.minOverrideLevel)
+	return zapcore.LevelOf(c.Core)
 }
 
 func (c *overrideCore) With(fields []zapcore.Field) zapcore.Core {
-	clone := c.clone()
-	for i := range fields {
-		fields[i].AddTo(c.enc)
+	return &overrideCore{
+		Core:      c.Core.With(fields),
+		level:     c.level,
+		overrides: c.overrides,
 	}
-	return clone
 }
 
 func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
 	if c.level.Enabled(ent.Level) {
-		return ce.AddCore(ent, c)
+		return c.Core.Check(ent, ce)
 	}
 
-	if !c.minOverrideLevel.Enabled(ent.Level) {
+	if !c.Core.Enabled(ent.Level) {
 		return ce
 	}
 
@@ -96,43 +94,9 @@ func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapco
 		}
 
 		if o.Level.Enabled(ent.Level) {
-			return ce.AddCore(ent, c)
+			return c.Core.Check(ent, ce)
 		}
 	}
 
 	return ce
-}
-
-func (c *overrideCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
-	buf, err := c.enc.EncodeEntry(ent, fields)
-	if err != nil {
-		return err
-	}
-	_, err = c.out.Write(buf.Bytes())
-	buf.Free()
-	if err != nil {
-		return err
-	}
-	if ent.Level > zapcore.ErrorLevel {
-		// Since we may be crashing the program, sync the output. Ignore Sync
-		// errors, pending a clean solution to issue #370.
-		c.Sync()
-	}
-	return nil
-}
-
-func (c *overrideCore) Sync() error {
-	return c.out.Sync()
-}
-
-func (c *overrideCore) clone() *overrideCore {
-	return &overrideCore{
-		enc: c.enc.Clone(),
-		out: c.out,
-
-		level:            c.level,
-		minOverrideLevel: c.minOverrideLevel,
-
-		overrides: c.overrides,
-	}
 }

--- a/internal/sinkcores/outputcore/override.go
+++ b/internal/sinkcores/outputcore/override.go
@@ -1,0 +1,94 @@
+package outputcore
+
+import (
+	"strings"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// Override allows adjusting the log level for specific scopes.
+type Override struct {
+	// Scope matches any zapcore.Entry with the name Scope or the prefix Scope + ".".
+	Scope string
+	// Level is the level to log at for zapcore.Entry's that match Scope.
+	Level zapcore.Level
+}
+
+// newOverrideCore will create a core with the specific overrides. newCore is
+// required because we need to adjust the level to allow the overrides to log.
+func newOverrideCore(level zapcore.LevelEnabler, overrides []Override, newCore func(zapcore.LevelEnabler) zapcore.Core) zapcore.Core {
+	// We need to adjust level we construct NewCore such that if a level is
+	// overriden we end up logging it.
+	minOverrideLevel := level
+	for _, o := range overrides {
+		if !minOverrideLevel.Enabled(o.Level) {
+			minOverrideLevel = o.Level
+		}
+	}
+
+	core := newCore(minOverrideLevel)
+
+	// Only use overrideCore if it could have an effect.
+	if minOverrideLevel == level {
+		return core
+	}
+
+	return &overrideCore{
+		Core:      core,
+		level:     level,
+		overrides: overrides,
+	}
+}
+
+// overrideCore wraps a core to additionally log a message if it matches
+// overrides or level.
+type overrideCore struct {
+	// Core is the wrapped core. Note its level must be lowered such that if a
+	// message matches an override it will be logged. Then we gate everything
+	// else with level.
+	zapcore.Core
+
+	// level is the passed in level before Core was lowered to take into account
+	// the overrides.
+	level zapcore.LevelEnabler
+
+	overrides []Override
+}
+
+func (c *overrideCore) Level() zapcore.Level {
+	return zapcore.LevelOf(c.Core)
+}
+
+func (c *overrideCore) With(fields []zapcore.Field) zapcore.Core {
+	return &overrideCore{
+		Core:      c.Core.With(fields),
+		level:     c.level,
+		overrides: c.overrides,
+	}
+}
+
+func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.level.Enabled(ent.Level) {
+		return c.Core.Check(ent, ce)
+	}
+
+	if !c.Core.Enabled(ent.Level) {
+		return ce
+	}
+
+	for _, o := range c.overrides {
+		if !strings.HasPrefix(ent.LoggerName, o.Scope) {
+			continue
+		}
+		// Check that if o.Scope != ent.LoggerName then it is a child logger
+		if len(ent.LoggerName) > len(o.Scope) && ent.LoggerName[len(o.Scope)] != '.' {
+			continue
+		}
+
+		if o.Level.Enabled(ent.Level) {
+			return c.Core.Check(ent, ce)
+		}
+	}
+
+	return ce
+}

--- a/internal/sinkcores/outputcore/override.go
+++ b/internal/sinkcores/outputcore/override.go
@@ -55,6 +55,9 @@ type overrideCore struct {
 	overrides []Override
 }
 
+// Level returns the level after lowering due to overrides. We need to return
+// the lowest possible level since child cores will shortcut based on this
+// level.
 func (c *overrideCore) Level() zapcore.Level {
 	return zapcore.LevelOf(c.Core)
 }

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -58,7 +58,7 @@ func initGlobal(level zapcore.Level) {
 	if err != nil {
 		panic(err)
 	}
-	core := outputcore.NewCore(output, level, encoders.OutputConsole, zap.SamplingConfig{})
+	core := outputcore.NewCore(output, level, encoders.OutputConsole, zap.SamplingConfig{}, nil)
 	// use an empty resource, we don't log output Resource in dev mode anyway
 	globallogger.Init(log.Resource{}, true, []zapcore.Core{core})
 }
@@ -102,7 +102,7 @@ func scopedTestLogger(t testing.TB, options LoggerOptions) log.Logger {
 		return outputcore.NewCore(&testingWriter{
 			t:          t,
 			markFailed: options.FailOnErrorLogs,
-		}, level, encoders.OutputConsole, zap.SamplingConfig{})
+		}, level, encoders.OutputConsole, zap.SamplingConfig{}, nil)
 	})
 }
 

--- a/sinks_output_test.go
+++ b/sinks_output_test.go
@@ -1,0 +1,153 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestOutputSink_Check(t *testing.T) {
+	// Unset any possible envvars that effect Check
+	for _, k := range []string{
+		EnvLogFormat,
+		EnvLogLevel,
+		EnvLogScopeLevel,
+		EnvLogSamplingInitial,
+		EnvLogSamplingThereafter,
+	} {
+		unsetenv(t, k)
+	}
+
+	logs := `
+foo debug
+foo error
+foo.bar debug
+foo.bar error
+foo.bar.baz debug
+foo.bar.baz error
+foo.bar.baz1 debug
+foo.bar.baz1 error
+`
+
+	cases := []struct {
+		Name string
+		Env  map[string]string
+		Want string
+	}{{
+		Name: "error",
+		Env: map[string]string{
+			EnvLogLevel: "error",
+		},
+		Want: `
+foo error
+foo.bar error
+foo.bar.baz error
+foo.bar.baz1 error
+`,
+	}, {
+		Name: "debug",
+		Env: map[string]string{
+			EnvLogLevel: "debug",
+		},
+		Want: logs,
+	}, {
+		Name: "none",
+		Env: map[string]string{
+			EnvLogLevel: "none",
+		},
+		Want: "",
+	}, {
+		Name: "scope",
+		Env: map[string]string{
+			EnvLogLevel:      "error",
+			EnvLogScopeLevel: "foo.bar=debug",
+		},
+		// Should be everything except foo debug
+		Want: `
+foo error
+foo.bar debug
+foo.bar error
+foo.bar.baz debug
+foo.bar.baz error
+foo.bar.baz1 debug
+foo.bar.baz1 error
+`,
+	}, {
+		Name: "scope two",
+		Env: map[string]string{
+			EnvLogLevel:      "error",
+			EnvLogScopeLevel: "foo.bar.baz=debug,foo.bar.baz1=debug",
+		},
+		// Should be everything except foo and foo.bar debug
+		Want: `
+foo error
+foo.bar error
+foo.bar.baz debug
+foo.bar.baz error
+foo.bar.baz1 debug
+foo.bar.baz1 error
+`,
+	}, {
+		Name: "scope deep",
+		Env: map[string]string{
+			EnvLogLevel:      "error",
+			EnvLogScopeLevel: "foo.bar.baz=debug",
+		},
+		Want: `
+foo error
+foo.bar error
+foo.bar.baz debug
+foo.bar.baz error
+foo.bar.baz1 error
+`,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			for k, v := range tc.Env {
+				t.Setenv(k, v)
+			}
+
+			core, err := (&outputSink{}).build()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			logParts := strings.Fields(logs)
+			got := ""
+			for len(logParts) >= 2 {
+				entry := zapcore.Entry{
+					LoggerName: logParts[0],
+					Level:      Level(logParts[1]).Parse(),
+				}
+				logParts = logParts[2:]
+
+				if core.Check(entry, nil) != nil {
+					got = fmt.Sprintf("%s%s %s\n", got, entry.LoggerName, entry.Level)
+				}
+			}
+
+			want := strings.TrimSpace(tc.Want)
+			got = strings.TrimSpace(got)
+
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected allowed logs (-want, +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func unsetenv(t *testing.T, key string) {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return
+	}
+	os.Unsetenv(key)
+	t.Cleanup(func() {
+		t.Setenv(key, v)
+	})
+}


### PR DESCRIPTION
SRC_LOG_SCOPE_LEVEL allows operators to override the log level for
specific loggers and there children. It is an comma seperated
environment variable which takes a logger name and level. If a log
message matches the logger name (or a parent of it does) AND the log
level allows it then it will always be logged. A parent is defined by
how we join scoped loggers with a ".".

The motivation for this is in production we log with very low verbosity,
but when testing a feature it can be useful to turn up the verbosity for
specific logs. For example while I was developing hybrid searcher it
would of been great to make just that debug, but avoid debug for
everything else due to the noise.

Test Plan: Added unit tests which test from the envar level.