### PR TITLE
outputcore: remove NewDevelopmentCore

### DIFF
--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -32,11 +32,3 @@ func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format enco
 	}
 	return core
 }
-
-func NewDevelopmentCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat) zapcore.Core {
-	return zapcore.NewCore(
-		encoders.BuildEncoder(encoders.OutputConsole, true),
-		output,
-		level,
-	)
-}

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -58,7 +58,7 @@ func initGlobal(level zapcore.Level) {
 	if err != nil {
 		panic(err)
 	}
-	core := outputcore.NewDevelopmentCore(output, level, encoders.OutputConsole)
+	core := outputcore.NewCore(output, level, encoders.OutputConsole, zap.SamplingConfig{})
 	// use an empty resource, we don't log output Resource in dev mode anyway
 	globallogger.Init(log.Resource{}, true, []zapcore.Core{core})
 }
@@ -99,10 +99,10 @@ func scopedTestLogger(t testing.TB, options LoggerOptions) log.Logger {
 		}
 
 		// replace the core entirely
-		return outputcore.NewDevelopmentCore(&testingWriter{
+		return outputcore.NewCore(&testingWriter{
 			t:          t,
 			markFailed: options.FailOnErrorLogs,
-		}, level, encoders.OutputConsole)
+		}, level, encoders.OutputConsole, zap.SamplingConfig{})
 	})
 }
 

--- a/sinks_output.go
+++ b/sinks_output.go
@@ -29,7 +29,7 @@ func (s *outputSink) build() (zapcore.Core, error) {
 	format := encoders.ParseOutputFormat(os.Getenv(EnvLogFormat))
 
 	if s.development {
-		return outputcore.NewDevelopmentCore(output, level, format), nil
+		format = encoders.OutputConsole
 	}
 
 	sampling, err := parseSamplingConfig()


### PR DESCRIPTION
This was just a wrapper around NewCore and additionally was misleading since it just ignored the passed in format.

Test Plan: go test ./...