### PR TITLE
use os.Setenv in unsetenv test helper

### DIFF
--- a/sinks_output_test.go
+++ b/sinks_output_test.go
@@ -148,6 +148,6 @@ func unsetenv(t *testing.T, key string) {
 	}
 	os.Unsetenv(key)
 	t.Cleanup(func() {
-		t.Setenv(key, v)
+		os.Setenv(key, v)
 	})
 }


### PR DESCRIPTION
Minor bug I just noticed. The unsetenv test helper needs to reset they process level environment variable, but using t.Setenv won't have that effect since it will just be cleaned up straight away.

Test Plan: go test