### PR TITLE
outputcore: correctly use dev mode to apply configuration

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/sourcegraph/log"
+)
+
+func main() {
+	liblog := log.Init(log.Resource{
+		Name: "logexample",
+	})
+	defer liblog.Sync()
+
+	l := log.Scoped("foo", "an example logger")
+
+	// print diagnostics
+	config := []log.Field{}
+	for _, k := range []string{
+		log.EnvDevelopment,
+		log.EnvLogFormat,
+		log.EnvLogLevel,
+		log.EnvLogScopeLevel,
+		log.EnvLogSamplingInitial,
+		log.EnvLogSamplingThereafter,
+	} {
+		config = append(config, log.String(k, os.Getenv(k)))
+	}
+	l.Info("configuration", config...)
+
+	// sample message
+	l.Warn("hello world!", log.Time("now", time.Now()))
+}

--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -4,15 +4,21 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log/internal/encoders"
-	"github.com/sourcegraph/log/internal/globallogger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig, overrides []Override) zapcore.Core {
+func NewCore(
+	output zapcore.WriteSyncer,
+	level zapcore.LevelEnabler,
+	format encoders.OutputFormat,
+	sampling zap.SamplingConfig,
+	overrides []Override,
+	development bool,
+) zapcore.Core {
 	newCore := func(level zapcore.LevelEnabler) zapcore.Core {
 		return zapcore.NewCore(
-			encoders.BuildEncoder(format, globallogger.DevMode()),
+			encoders.BuildEncoder(format, development),
 			output,
 			level,
 		)

--- a/internal/sinkcores/outputcore/core.go
+++ b/internal/sinkcores/outputcore/core.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log/internal/encoders"
+	"github.com/sourcegraph/log/internal/globallogger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -11,7 +12,7 @@ import (
 func NewCore(output zapcore.WriteSyncer, level zapcore.LevelEnabler, format encoders.OutputFormat, sampling zap.SamplingConfig, overrides []Override) zapcore.Core {
 	newCore := func(level zapcore.LevelEnabler) zapcore.Core {
 		return zapcore.NewCore(
-			encoders.BuildEncoder(format, false),
+			encoders.BuildEncoder(format, globallogger.DevMode()),
 			output,
 			level,
 		)

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -58,7 +58,7 @@ func initGlobal(level zapcore.Level) {
 	if err != nil {
 		panic(err)
 	}
-	core := outputcore.NewCore(output, level, encoders.OutputConsole, zap.SamplingConfig{}, nil)
+	core := outputcore.NewCore(output, level, encoders.OutputConsole, zap.SamplingConfig{}, nil, true)
 	// use an empty resource, we don't log output Resource in dev mode anyway
 	globallogger.Init(log.Resource{}, true, []zapcore.Core{core})
 }
@@ -102,7 +102,7 @@ func scopedTestLogger(t testing.TB, options LoggerOptions) log.Logger {
 		return outputcore.NewCore(&testingWriter{
 			t:          t,
 			markFailed: options.FailOnErrorLogs,
-		}, level, encoders.OutputConsole, zap.SamplingConfig{}, nil)
+		}, level, encoders.OutputConsole, zap.SamplingConfig{}, nil, true)
 	})
 }
 

--- a/sinks_output.go
+++ b/sinks_output.go
@@ -43,7 +43,7 @@ func (s *outputSink) build() (zapcore.Core, error) {
 		return nil, err
 	}
 
-	return outputcore.NewCore(output, level, format, sampling, overrides), nil
+	return outputcore.NewCore(output, level, format, sampling, overrides, s.development), nil
 }
 
 // update is a no-op because outputSink cannot be changed live.


### PR DESCRIPTION
`encoders.BuildEncoder` relies on the `development bool` argument to assess whether to apply our dev config for easier-to-read output. It looks like we no longer call `BuildEncoder` with anything except `development: false` - I don't recall what it used to be, but setting it to `globallogger.DevMode()` should fix it. We can't place this in `BuildEncoder` itself because that would cause an import cycle between package `encoders` and `globallogger`.

Since we have `(*outputSink).development` available, however, I've opted to prop-drill it in to `NewCore` from the top-level variable. `development` is a bit problematic to work with - we might want to better refactor the interactions here at some point.

Test plan: I added a sanity-check program, `cmd/example`, to do some quick-and-easy visual confirmation of log output.

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/23356519/205734002-bbe00f35-5613-4726-ae24-5097a05d6a56.png">