### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Setup
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Run lsif-go
       - name: Run lsif-go


### PR DESCRIPTION
Update to actions/checkout@v3 to avoid deprecation warning

### Test plan
Created as part of batch change: [_Created by Sourcegraph batch change `sourcegraph-operator-dax/Upgrade_actions_checkout_v2-v3`._](https://sourcegraph.sourcegraph.com/users/sourcegraph-operator-dax/batch-changes/Upgrade_actions_checkout_v2-v3)