### PR TITLE
logr: add a way to get the underlying log.Logger

### DIFF
--- a/logr/logger.go
+++ b/logr/logger.go
@@ -1,0 +1,18 @@
+package logr
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/sourcegraph/log"
+)
+
+// GetLogger retrieves the underlying log.Logger. If no Logger is found,
+// a Logger scoped to 'logr' is returned. The second return value can be
+// checked if such a Logger was created.
+func GetLogger(l logr.Logger) (log.Logger, bool) {
+	sink, ok := l.GetSink().(*LogSink)
+	if !ok {
+		return log.Scoped("logr", "new log.Logger created from logr.Logger"), false
+	}
+	return sink.Logger, true
+}

--- a/logr/logger_test.go
+++ b/logr/logger_test.go
@@ -1,0 +1,24 @@
+package logr
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLogger(t *testing.T) {
+	logr := New(logtest.Scoped(t))
+
+	t.Run("from the root", func(t *testing.T) {
+		logger, ok := GetLogger(logr)
+		assert.True(t, ok)
+		assert.NotNil(t, logger)
+	})
+
+	t.Run("from a named sub-logger", func(t *testing.T) {
+		logger, ok := GetLogger(logr.WithName("foobar"))
+		assert.True(t, ok)
+		assert.NotNil(t, logger)
+	})
+}

--- a/logr/logr.go
+++ b/logr/logr.go
@@ -7,6 +7,10 @@ import (
 	"github.com/sourcegraph/log"
 )
 
+// New instantiates a new logr.Logger that sends entries to the given
+// log.Logger.
+func New(l log.Logger) logr.Logger { return logr.New(&LogSink{Logger: l}) }
+
 // LogSink implements logr.LogSink, backed by a sourcegraph/log.Logger.
 type LogSink struct{ log.Logger }
 


### PR DESCRIPTION
Allows us to retrieve a preconfigured log.Logger from a preconfigured logr.Logger, which is provided to us in kubebuilder handlers.