### PR TITLE
logtest: add Filter, Contains on CapturedLogs

### DIFF
--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -82,6 +82,28 @@ func (cl CapturedLogs) Messages() []string {
 	return messages
 }
 
+// Filter returns captured logs that match the condition.
+func (cl CapturedLogs) Filter(condition func(l CapturedLog) bool) CapturedLogs {
+	var filtered CapturedLogs
+	for _, l := range cl {
+		if condition(l) {
+			filtered = append(filtered, l)
+		}
+	}
+	return filtered
+}
+
+// Contains asserts that at least one entry matching the condition exists in the captured
+// logs.
+func (cl CapturedLogs) Contains(condition func(l CapturedLog) bool) bool {
+	for _, l := range cl {
+		if condition(l) {
+			return true
+		}
+	}
+	return false
+}
+
 type LoggerOptions struct {
 	// Level configures the minimum log level to output.
 	Level log.Level

--- a/logtest/logtest_test.go
+++ b/logtest/logtest_test.go
@@ -13,12 +13,23 @@ func TestExport(t *testing.T) {
 	assert.NotNil(t, logger)
 
 	logger.Info("hello world", log.String("key", "value"))
+	logger.Error("goodbye world", log.String("key", "value"))
 
 	logs := exportLogs()
-	assert.Len(t, logs, 1)
-	assert.Equal(t, "TestExport", logs[0].Scope)
-	assert.Equal(t, "hello world", logs[0].Message)
+	assert.Len(t, logs, 2)
+	assert.Equal(t, "TestExport", logs[0].Scope)    // test name is the scope
+	assert.Equal(t, "hello world", logs[0].Message) // retains the message
 
-	// In dev mode, attributes are not added
+	// In dev mode, attributes are not added, but custom fields are retained
 	assert.Equal(t, map[string]interface{}{"key": "value"}, logs[0].Fields)
+
+	// We can filter for entries
+	assert.Len(t, logs.Filter(func(l CapturedLog) bool {
+		return l.Level == log.LevelError
+	}), 1)
+
+	// We can assert the existence of an entry
+	assert.False(t, logs.Contains(func(l CapturedLog) bool {
+		return l.Level == log.LevelWarn
+	}))
 }


### PR DESCRIPTION
Finding a particular entry or set of entries is a pretty common assertion - in #55 I added a slice type `CapturedLogs`, which can become a home for some simple utilities to help with asserting particular entries get logged.