### PR TITLE
sentrycore: add first-class metadata from resource

### DIFF
--- a/internal/sinkcores/sentrycore/integration_test.go
+++ b/internal/sinkcores/sentrycore/integration_test.go
@@ -89,17 +89,23 @@ func TestTags(t *testing.T) {
 		assert.Equal(t, tr.Events()[0].Tags["scope"], "TestTags/scope.my-scope")
 	})
 
-	t.Run("service_name", func(t *testing.T) {
+	t.Run("resource", func(t *testing.T) {
 		logger, tr, sync := newTestLogger(t)
 		resource := log.Resource{
-			Name:    "foobar",
-			Version: "123",
+			Name:       "foobar",
+			Version:    "123",
+			InstanceID: "hostname",
 		}
 		logger.Error("msg", log.Error(e), zap.Object(otelfields.ResourceFieldKey, &encoders.ResourceEncoder{Resource: resource}))
 		sync()
 		assert.Len(t, tr.Events(), 1)
-		assert.Equal(t, tr.Events()[0].Tags["resource.service.name"], "foobar")
-		assert.Equal(t, tr.Events()[0].Tags["resource.service.version"], "123")
+		assert.Equal(t, "foobar", tr.Events()[0].Tags["resource.service.name"])
+
+		assert.Equal(t, "123", tr.Events()[0].Tags["resource.service.version"])
+		assert.Equal(t, "123", tr.Events()[0].Release)
+
+		assert.Equal(t, "hostname", tr.Events()[0].Tags["resource.service.instance.id"])
+		assert.Equal(t, "hostname", tr.Events()[0].ServerName)
 	})
 }
 

--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -137,12 +137,15 @@ func (w *worker) capture(errCtx *errorContext) {
 				tags["resource.service.name"] = r.Name
 				if r.Version != "" {
 					tags["resource.service.version"] = r.Version
+					event.Release = r.Version
 				}
 				if r.Namespace != "" {
 					tags["resource.service.namespace"] = r.Namespace
+					event.Environment = r.Namespace
 				}
 				if r.InstanceID != "" {
 					tags["resource.service.instance.id"] = r.InstanceID
+					event.ServerName = r.InstanceID
 				}
 			}
 		}

--- a/sinks.go
+++ b/sinks.go
@@ -30,7 +30,6 @@ type SinksConfigGetter func() SinksConfig
 func (s sinks) update(get SinksConfigGetter) func() {
 	return func() {
 		updated := get()
-
 		for _, sink := range s {
 			if err := sink.update(updated); err != nil {
 				Scoped("log.sinks.update", "configuration updates").


### PR DESCRIPTION
Sentry has some fancy features around version tracking, environments, and whatnot - this change propagates relevant fields from the resource we initialize everything with onto events so that we might be able to take advantage of it.