### PR TITLE
sentrycore: disable if sentry config is nil

### DIFF
--- a/sinks_sentry.go
+++ b/sinks_sentry.go
@@ -48,7 +48,8 @@ func (s *sentrySink) build() (zapcore.Core, error) {
 
 func (s *sentrySink) update(updated SinksConfig) error {
 	if updated.Sentry == nil {
-		return nil
+		// use zero-value, effectively disabling sentry next
+		updated.Sentry = &SentrySink{}
 	}
 
 	if cmp.Equal(s.ClientOptions, updated.Sentry.ClientOptions) {


### PR DESCRIPTION
Right now, removing Sentry config doesn't disable it because we return immediately here.