### PR TITLE
Add a new format, `JSON_GCP`

### DIFF
--- a/init.go
+++ b/init.go
@@ -14,7 +14,7 @@ var (
 	// EnvLogFormat is key of the environment variable that is used to set the log format
 	// on Init.
 	//
-	// The value should be one of 'json' or 'console', defaulting to 'json'.
+	// The value should be one of 'json', 'json_gcp' or 'condensed', defaulting to 'json'.
 	EnvLogFormat = "SRC_LOG_FORMAT"
 	// EnvLogLevel is key of the environment variable that can be used to set the log
 	// level on Init.

--- a/output/output.go
+++ b/output/output.go
@@ -22,14 +22,16 @@ func ParseFormat(format string) Format {
 	switch format {
 	case string(FormatJSONGCP):
 		return FormatJSONGCP
+
+	// True 'logfmt' has significant limitations around certain field types:
+	// https://github.com/jsternberg/zap-logfmt#limitations so since it implies a
+	// desire for a somewhat structured format, we interpret it as OutputJSON.
 	case string(FormatJSON), "logfmt":
-		// True 'logfmt' has significant limitations around certain field types:
-		// https://github.com/jsternberg/zap-logfmt#limitations so since it implies a
-		// desire for a somewhat structured format, we interpret it as OutputJSON.
 		return FormatJSON
+
+	// The previous 'condensed' format is optimized for local dev, so it serves the
+	// same purpose as OutputConsole
 	case string(FormatConsole), "condensed":
-		// The previous 'condensed' format is optimized for local dev, so it serves the
-		// same purpose as OutputConsole
 		return FormatConsole
 	}
 

--- a/output/output.go
+++ b/output/output.go
@@ -7,6 +7,10 @@ const (
 	// FormatJSON encodes log entries to a machine-readable, OpenTelemetry-structured
 	// format.
 	FormatJSON Format = "json"
+	// FormatJSONGCP encodes log entries to a machine-readable, GCP-structured format.
+	// It's similar to OpenTelemetry-structured format, but the severity field
+	// complies with https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+	FormatJSONGCP Format = "json_gcp"
 	// FormatConsole encodes log entries to a human-readable format.
 	FormatConsole Format = "console"
 )
@@ -16,16 +20,16 @@ const (
 // log formats.
 func ParseFormat(format string) Format {
 	switch format {
-	case string(FormatJSON),
+	case string(FormatJSONGCP):
+		return FormatJSONGCP
+	case string(FormatJSON), "logfmt":
 		// True 'logfmt' has significant limitations around certain field types:
 		// https://github.com/jsternberg/zap-logfmt#limitations so since it implies a
 		// desire for a somewhat structured format, we interpret it as OutputJSON.
-		"logfmt":
 		return FormatJSON
-	case string(FormatConsole),
+	case string(FormatConsole), "condensed":
 		// The previous 'condensed' format is optimized for local dev, so it serves the
 		// same purpose as OutputConsole
-		"condensed":
 		return FormatConsole
 	}
 


### PR DESCRIPTION
When deploying a service that sends out logs to cloud logging, the severity was not parsed and because logs of our services are all sent out of STDERR, they all defaulted to `severity: "ERROR"`, making it quite hard to read. 

This PRs adds a new `SRC_LOG_FORMAT=json_gcp`, which outputs json logs in a structure that cloud logging understands. 

See the results of a little test in Cloud run: 

![image](https://github.com/sourcegraph/log/assets/10151/88b81ae5-936f-4f63-a22e-7ad7796151e2)
