### PR TITLE
remove description

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -13,7 +13,7 @@ func main() {
 	})
 	defer liblog.Sync()
 
-	l := log.Scoped("foo", "an example logger")
+	l := log.Scoped("foo")
 
 	// print diagnostics
 	config := []log.Field{}

--- a/init.go
+++ b/init.go
@@ -98,7 +98,7 @@ func Init(r Resource, s ...Sink) *PostInitCallbacks {
 
 	if sinksBuildErr != nil {
 		// Log the error
-		Scoped("log.init", "logger initialization").
+		Scoped("log.init").
 			Fatal("sinks initialization failed", Error(sinksBuildErr))
 	}
 

--- a/internal/configurable/logger_test.go
+++ b/internal/configurable/logger_test.go
@@ -14,7 +14,7 @@ func TestCast(t *testing.T) {
 		log.Init(log.Resource{Name: t.Name()})
 
 		// Cast works
-		cl := configurable.Cast(log.Scoped("foo", "bar"))
+		cl := configurable.Cast(log.Scoped("foo"))
 
 		// Core wrapping works
 		_ = cl.WithCore(func(c zapcore.Core) zapcore.Core {

--- a/internal/sinkcores/sentrycore/integration_test.go
+++ b/internal/sinkcores/sentrycore/integration_test.go
@@ -82,7 +82,7 @@ func TestTags(t *testing.T) {
 	e := errors.New("test error")
 	t.Run("scope", func(t *testing.T) {
 		logger, tr, sync := newTestLogger(t)
-		logger = logger.Scoped("my-scope", "testing scope tags")
+		logger = logger.Scoped("my-scope")
 		logger.Error("msg", log.Error(e))
 		sync()
 		assert.Len(t, tr.Events(), 1)

--- a/logger.go
+++ b/logger.go
@@ -30,7 +30,7 @@ type Logger interface {
 	//
 	// Scopes map to OpenTelemetry InstrumentationScopes:
 	// https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-instrumentationscope
-	Scoped(scope string, description string) Logger
+	Scoped(scope string) Logger
 
 	// With creates a new Logger with the given fields as attributes.
 	//
@@ -87,7 +87,7 @@ type Logger interface {
 //
 // When testing, you should use 'logtest.Scoped(*testing.T)' instead - learn more:
 // https://docs.sourcegraph.com/dev/how-to/add_logging#testing-usage
-func Scoped(scope string, description string) Logger {
+func Scoped(scope string) Logger {
 	safeGet := !globallogger.DevMode() // do not panic in prod
 	root := globallogger.Get(safeGet)
 	adapted := &zapAdapter{
@@ -99,9 +99,9 @@ func Scoped(scope string, description string) Logger {
 	if globallogger.DevMode() {
 		// In development, don't add the OpenTelemetry "Attributes" namespace which gets
 		// rather difficult to read.
-		return adapted.Scoped(scope, description)
+		return adapted.Scoped(scope)
 	}
-	return adapted.Scoped(scope, description).With(otelfields.AttributesNamespace)
+	return adapted.Scoped(scope).With(otelfields.AttributesNamespace)
 }
 
 // NoOp returns a no-op Logger that can never produce any output. It can be safely created
@@ -137,7 +137,7 @@ type zapAdapter struct {
 
 var _ Logger = &zapAdapter{}
 
-func (z *zapAdapter) Scoped(scope string, description string) Logger {
+func (z *zapAdapter) Scoped(scope string) Logger {
 	var newFullScope string
 	if z.fullScope == "" {
 		newFullScope = scope

--- a/logtest/logtest.go
+++ b/logtest/logtest.go
@@ -119,7 +119,7 @@ func scopedTestLogger(t testing.TB, options LoggerOptions) log.Logger {
 	// On cleanup, flush the global logger.
 	t.Cleanup(func() { globallogger.Get(true).Sync() })
 
-	root := log.Scoped(t.Name(), "")
+	root := log.Scoped(t.Name())
 
 	// Cast into internal API
 	cl := configurable.Cast(root)

--- a/sinks.go
+++ b/sinks.go
@@ -32,7 +32,7 @@ func (s sinks) update(get SinksConfigGetter) func() {
 		updated := get()
 		for _, sink := range s {
 			if err := sink.update(updated); err != nil {
-				Scoped("log.sinks.update", "configuration updates").
+				Scoped("log.sinks.update").
 					Error("failed to update", String("sink", sink.Name()), Error(err))
 			}
 		}


### PR DESCRIPTION
As the great @bobheadxi once upon a time said

> aside: the scope description parameter in general is pretty useless as well, maybe someone can do the honors of getting rid of that as well :)
- Robert, circa 2023 [PR](https://github.com/sourcegraph/log/pull/62)

Related:
- https://github.com/sourcegraph/sourcegraph/pull/57690
- https://github.com/sourcegraph/zoekt/pull/657
- https://github.com/sourcegraph/mountinfo/pull/5