### PR TITLE
sentrycore: emit trace ID, span ID in Sentry-specific trace context as well

### DIFF
--- a/internal/sinkcores/sentrycore/integration_test.go
+++ b/internal/sinkcores/sentrycore/integration_test.go
@@ -134,6 +134,10 @@ func TestWithTrace(t *testing.T) {
 	attrs := tr.Events()[0].Contexts["log"]
 	assert.Equal(t, "123", attrs["TraceId"])
 	assert.Equal(t, "456", attrs["SpanId"])
+	// Also reflect trace into Sentry's specialized trace context
+	traceAttrs := tr.Events()[0].Contexts["trace"]
+	assert.Equal(t, "123", traceAttrs["trace_id"])
+	assert.Equal(t, "456", traceAttrs["span_id"])
 }
 
 func TestFields(t *testing.T) {

--- a/internal/sinkcores/sentrycore/worker.go
+++ b/internal/sinkcores/sentrycore/worker.go
@@ -189,6 +189,14 @@ func (w *worker) capture(errCtx *errorContext) {
 	w.hub.hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetExtras(extraDetails)
 		scope.SetContext("log", enc.Fields)
+		if enc.Fields != nil {
+			// Also reflect trace into Sentry's specialized trace context
+			// https://develop.sentry.dev/sdk/event-payloads/contexts/#trace-context
+			scope.SetContext("trace", sentry.Context{
+				"trace_id": enc.Fields["TraceId"],
+				"span_id":  enc.Fields["SpanId"],
+			})
+		}
 		scope.SetTags(tags)
 		scope.SetLevel(level)
 		w.hub.hub.CaptureEvent(event)


### PR DESCRIPTION
Following https://develop.sentry.dev/sdk/event-payloads/contexts/#trace-context - looks like Sentry might have some special UI presentation/categorization capabilities around this