### PR TITLE
feat(overrides): updated overrideCore to allow filtering out logs at a higher level

### DIFF
--- a/init.go
+++ b/init.go
@@ -30,7 +30,7 @@ var (
 	// Notes:
 	//
 	//  - these levels do not respect the root level (SRC_LOG_LEVEL), so this
-	//    allows operators to turn up the verbosity of specific logs.
+	//    allows operators to turn up or down the verbosity of specific logs.
 	//  - this only affects the outputcore (ie will not effect sentrycore).
 	//  - Scope matches the full scope name. IE the below example has the scope
 	//    "foo.bar" not "bar".

--- a/internal/sinkcores/outputcore/override.go
+++ b/internal/sinkcores/outputcore/override.go
@@ -71,6 +71,7 @@ func (c *overrideCore) With(fields []zapcore.Field) zapcore.Core {
 }
 
 func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+
 	// First check if any overrides match this logger
 	for _, o := range c.overrides {
 
@@ -86,7 +87,7 @@ func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapco
 		if o.Level.Enabled(ent.Level) {
 			return c.Core.Check(ent, ce)
 		}
-		break
+		return ce
 	}
 
 	// If no overrides matched or the override allowed it, check the base level
@@ -99,5 +100,6 @@ func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapco
 		return ce
 	}
 
+	// allowed!
 	return c.Core.Check(ent, ce)
 }

--- a/internal/sinkcores/outputcore/override.go
+++ b/internal/sinkcores/outputcore/override.go
@@ -71,10 +71,7 @@ func (c *overrideCore) With(fields []zapcore.Field) zapcore.Core {
 }
 
 func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-
-	// First check if any overrides match this logger
 	for _, o := range c.overrides {
-
 		if !strings.HasPrefix(ent.LoggerName, o.Scope) {
 			continue
 		}
@@ -83,23 +80,19 @@ func (c *overrideCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapco
 			continue
 		}
 
-		// If we found a matching override, use its level check
 		if o.Level.Enabled(ent.Level) {
 			return c.Core.Check(ent, ce)
 		}
 		return ce
 	}
 
-	// If no overrides matched or the override allowed it, check the base level
-	if !c.level.Enabled(ent.Level) {
-		return ce
+	if c.level.Enabled(ent.Level) {
+		return c.Core.Check(ent, ce)
 	}
 
-	// Finally check if the core itself allows this level
 	if !c.Core.Enabled(ent.Level) {
 		return ce
 	}
 
-	// allowed!
-	return c.Core.Check(ent, ce)
+	return ce
 }


### PR DESCRIPTION
As per our discussion in [slack](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1741728615123969), I think it would be nice to allow override logs to raise the level of severity. To that end, my proposed changes are:
* Always return an override core if overrides are provided
* Check overrides first in override core, and then fall back to base levels

I acknowledge this does introduce a performance hit when SRC_LOG_SCOPE_LEVEL is defined, but I doubt it's significant. If we're concerned, I could put this behavior behind an env var like SRC_LOG_OVERRIDES_CAN_INCREASE_SEVERITY (not the punchiest, but gets the point across). However, I'd personally prefer if it was the default because I was surprised by the current behavior and clearly thought it was a bug.

## Test Plan
Updated and added unit test

Closes https://linear.app/sourcegraph/issue/DINF-819/sg-start-not-respecting-src-log-scope-level-variable