### PR TITLE
Re-export zapcore types for implementing custom marshalers

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,12 @@
+package log
+
+import "go.uber.org/zap/zapcore"
+
+type ArrayEncoder = zapcore.ArrayEncoder
+type ObjectEncoder = zapcore.ObjectEncoder
+
+type ArrayMarshaler = zapcore.ArrayMarshaler
+type ObjectMarshaler = zapcore.ObjectMarshaler
+
+type ArrayMarshalerFunc = zapcore.ArrayMarshalerFunc
+type ObjectMarshalerFunc = zapcore.ObjectMarshalerFunc

--- a/fields.go
+++ b/fields.go
@@ -111,6 +111,12 @@ var (
 	// This helps prevent key collisions when injecting loggers into sub-components or
 	// third-party libraries.
 	Namespace = zap.Namespace
+
+	// CustomObject constructs a field that carries an object which implements the
+	// ObjectMarshaler interface.
+	CustomObject = zap.Object
+	// (Use a different name above to avoid breaking back-compat, since the
+	// Object func below already has 100+ usages in sg/sg as of 2025-07-17.)
 )
 
 // Object constructs a field that places all the given fields within the given key's


### PR DESCRIPTION
I'm hitting a depguard error in the sg monorepo when trying
to use these types as part of codeintel-related logic.

So changing the code here to re-export them.

Corresponding PR in Sourcegraph monorepo: https://github.com/sourcegraph/sourcegraph/pull/6661